### PR TITLE
Add `bot.clid` and `bot.cldbid` instance variable

### DIFF
--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -67,6 +67,7 @@ class TSBot:
         self.nickname = nickname
         self.server_id = server_id
         self.uid: str = ""
+        self.clid: str = ""
 
         self.plugins: dict[str, plugin.TSPlugin] = {}
 
@@ -437,10 +438,11 @@ class TSBot:
             for event in ("server", "textserver", "textchannel", "textprivate"):
                 await self.send(notify_query.params(event=event))
 
-        async def update_uid() -> None:
+        async def update_bot_info() -> None:
             """Gets the uid of the client"""
             resp = await self.send_raw("whoami")
             self.uid = resp.first["client_unique_identifier"]
+            self.clid = resp.first["client_id"]
 
         self.register_task(self._event_handler.handle_events_task, name="HandleEvents-Task")
         self.register_event_handler("textmessage", self._command_handler.handle_command_event)
@@ -458,7 +460,7 @@ class TSBot:
             logger.info("Connected")
 
             await select_server()
-            await update_uid()
+            await update_bot_info()
             await register_notifies()
 
             self.emit(event_name="ready")

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -430,7 +430,7 @@ class TSBot:
             await self.send(select_query)
 
         async def register_notifies() -> None:
-            """Coroutine to register server to send events to the bot"""
+            """Register server to send events to the bot"""
 
             notify_query = query_builder.TSQuery("servernotifyregister")
 
@@ -439,7 +439,7 @@ class TSBot:
                 await self.send(notify_query.params(event=event))
 
         async def update_bot_info() -> None:
-            """Gets the uid of the client"""
+            """Update useful information about the bot instance"""
             resp = await self.send_raw("whoami")
             self.uid = resp.first["client_unique_identifier"]
             self.clid = resp.first["client_id"]

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -66,8 +66,10 @@ class TSBot:
 
         self.nickname = nickname
         self.server_id = server_id
+
         self.uid: str = ""
         self.clid: str = ""
+        self.cldbid: str = ""
 
         self.plugins: dict[str, plugin.TSPlugin] = {}
 
@@ -440,9 +442,10 @@ class TSBot:
 
         async def update_bot_info() -> None:
             """Update useful information about the bot instance"""
-            resp = await self.send_raw("whoami")
-            self.uid = resp.first["client_unique_identifier"]
-            self.clid = resp.first["client_id"]
+            info = (await self.send_raw("whoami")).first
+            self.uid = info["client_unique_identifier"]
+            self.clid = info["client_id"]
+            self.cldbid = info["client_database_id"]
 
         self.register_task(self._event_handler.handle_events_task, name="HandleEvents-Task")
         self.register_event_handler("textmessage", self._command_handler.handle_command_event)


### PR DESCRIPTION
Before you would have to query `whoami` from the server to find your own *client id* or *client database id*.
Since the bot already queries it in `bot.run()` method, it doesn't take much to add the `clid` and `cldbid` to instance.

This can be used in queries where bots own `clid` or `cldbid` is needed. (eg. moving the bot client to another channel, adding the bot client to a server group)