### PR TITLE
Command self check

### DIFF
--- a/tsbot/commands/handler.py
+++ b/tsbot/commands/handler.py
@@ -47,7 +47,7 @@ class CommandHandler:
         """Logic to handle commands"""
 
         # If sender is the bot, return
-        if ctx.get("invokeruid") == bot.uid:
+        if ctx.get("invokerid") == bot.clid:
             return
 
         msg = ctx.get("msg", "").strip()


### PR DESCRIPTION
Change bot's self-check from uid to clid.

This allows clients that share the same identity (*uid*) with the bot, to interact with it.

Closes #47 