### PR TITLE
Improve logging

### DIFF
--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import inspect
-import logging
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Concatenate, NamedTuple, ParamSpec
 
@@ -24,8 +23,6 @@ if TYPE_CHECKING:
     from tsbot import plugin
 
 _P = ParamSpec("_P")
-
-logger = logging.getLogger(__name__)
 
 
 class BotInfo(NamedTuple):

--- a/tsbot/commands/handler.py
+++ b/tsbot/commands/handler.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
-from tsbot import context, enums, exceptions
+from tsbot import context, enums, exceptions, logging
 
 if TYPE_CHECKING:
     from tsbot import bot, commands
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 
 _ERROR_EVENT_MAP: dict[type[exceptions.TSException], str] = {

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import itertools
-import logging
 from typing import TYPE_CHECKING
 
-from tsbot import exceptions, query_builder
+from tsbot import exceptions, logging, query_builder
 from tsbot.connection import reader, writer
 
 if TYPE_CHECKING:
     from tsbot import bot, connection, events, ratelimiter, response
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 
 class TSConnection:

--- a/tsbot/connection/reader.py
+++ b/tsbot/connection/reader.py
@@ -3,17 +3,16 @@ from __future__ import annotations
 import asyncio
 import collections
 import contextlib
-import logging
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING
 
-from tsbot import events, response
+from tsbot import events, logging, response
 
 if TYPE_CHECKING:
     from tsbot import connection
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 
 class _ReadBuffer:

--- a/tsbot/default_plugins/keepalive.py
+++ b/tsbot/default_plugins/keepalive.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import TYPE_CHECKING
 
-from tsbot import plugin
+from tsbot import logging, plugin
 
 if TYPE_CHECKING:
     from tsbot import bot, context, tasks
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 
 class KeepAlive(plugin.TSPlugin):

--- a/tsbot/events/handler.py
+++ b/tsbot/events/handler.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import sys
 import warnings
 from collections import defaultdict
 from pathlib import Path  # type: ignore
 from typing import TYPE_CHECKING
 
-from tsbot import utils
+from tsbot import logging, utils
 
 if TYPE_CHECKING:
     from tsbot import bot, events
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 
 class EventHandler:

--- a/tsbot/logging.py
+++ b/tsbot/logging.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import MutableMapping
-from typing import Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
+
+if TYPE_CHECKING:
+    _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
+else:
+    _LoggerAdapter = logging.LoggerAdapter
+
 
 _logger = logging.getLogger(__package__ or "tsbot")
 
@@ -11,7 +17,7 @@ class LoggerExtra(TypedDict):
     from_module: str
 
 
-class TSBotLogger(logging.LoggerAdapter[logging.Logger]):
+class TSBotLogger(_LoggerAdapter):
     _debug: bool = False
 
     def __init__(self, logger: logging.Logger, extra: LoggerExtra) -> None:

--- a/tsbot/logging.py
+++ b/tsbot/logging.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
+# TODO: Python 3.10 compat. Remove when 3.10 EOL
 if TYPE_CHECKING:
     _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
 else:

--- a/tsbot/logging.py
+++ b/tsbot/logging.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import MutableMapping
 from typing import Any, TypedDict, cast
 
-_logger = logging.getLogger(__package__)
+_logger = logging.getLogger(__package__ or "tsbot")
 
 
 class LoggerExtra(TypedDict):

--- a/tsbot/logging.py
+++ b/tsbot/logging.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import MutableMapping
+from typing import Any, TypedDict, cast
+
+_logger = logging.getLogger(__package__)
+
+
+class LoggerExtra(TypedDict):
+    from_module: str
+
+
+class TSBotLogger(logging.LoggerAdapter[logging.Logger]):
+    _debug: bool = False
+
+    def __init__(self, logger: logging.Logger, extra: LoggerExtra) -> None:
+        super().__init__(logger, extra)
+
+    @classmethod
+    def set_debug(cls, value: bool):
+        cls._debug = value
+
+    def process(
+        self, msg: str, kwargs: MutableMapping[str, Any]
+    ) -> tuple[str, MutableMapping[str, Any]]:
+        if self._debug:
+            msg = f"[{cast(LoggerExtra,self.extra)['from_module']}] {msg}"
+
+        return super().process(msg, kwargs)
+
+
+def get_logger(name: str):
+    return TSBotLogger(_logger, {"from_module": name.removeprefix(f"{__package__}.")})
+
+
+def set_debug(value: bool):
+    TSBotLogger.set_debug(value)

--- a/tsbot/ratelimiter.py
+++ b/tsbot/ratelimiter.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 
-logger = logging.getLogger(__name__)
+from tsbot import logging
+
+logger = logging.get_logger(__name__)
 
 
 class RateLimiter:

--- a/tsbot/tasks/handler.py
+++ b/tsbot/tasks/handler.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import TYPE_CHECKING
+
+from tsbot import logging
 
 if TYPE_CHECKING:
     from tsbot import bot, tasks
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 
 class TasksHandler:


### PR DESCRIPTION
### Notable changes:
- TSBot will only create one logger.
- Calling `tsbot.logging.set_debug(True)` will prefix bots inner modules to the message.