### PR TITLE
Raw connection

### DIFF
--- a/tsbot/connection/__init__.py
+++ b/tsbot/connection/__init__.py
@@ -1,4 +1,4 @@
 from tsbot.connection.connection import TSConnection
-from tsbot.connection.connection_types import SSHConnection, abc
+from tsbot.connection.connection_types import RawConnection, SSHConnection, abc
 
-__all__ = ("abc", "TSConnection", "SSHConnection")
+__all__ = ("abc", "TSConnection", "RawConnection", "SSHConnection")

--- a/tsbot/connection/connection_types/__init__.py
+++ b/tsbot/connection/connection_types/__init__.py
@@ -1,3 +1,4 @@
+from tsbot.connection.connection_types.raw_connection import RawConnection
 from tsbot.connection.connection_types.ssh_connection import SSHConnection
 
-__all__ = ("SSHConnection",)
+__all__ = ("SSHConnection", "RawConnection")

--- a/tsbot/connection/connection_types/abc.py
+++ b/tsbot/connection/connection_types/abc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 
 

--- a/tsbot/connection/connection_types/abc.py
+++ b/tsbot/connection/connection_types/abc.py
@@ -44,7 +44,3 @@ class Connection(ABC):
     @abstractmethod
     async def readline(self) -> str | None:
         """Reads a single line."""
-
-    @abstractmethod
-    async def readuntil(self, separator: str) -> str | None:
-        """Reads until given separator."""

--- a/tsbot/connection/connection_types/abc.py
+++ b/tsbot/connection/connection_types/abc.py
@@ -51,4 +51,8 @@ class Connection(ABC):
 
     @abstractmethod
     async def readline(self) -> str | None:
-        """Reads a single line determined by line ending sequence."""
+        """
+        Reads a single line determined by line ending sequence.
+
+        Will include line ending sequence in return str
+        """

--- a/tsbot/connection/connection_types/abc.py
+++ b/tsbot/connection/connection_types/abc.py
@@ -29,6 +29,8 @@ class Connection(ABC):
 
         This method is called after the header is validated.
         Normal communication with the server allowed.
+
+        Will raise `ConnectionAbortedError` if cannot authenticate connection.
         """
 
     @abstractmethod
@@ -41,8 +43,12 @@ class Connection(ABC):
 
     @abstractmethod
     async def write(self, data: str) -> None:
-        """Write data to the server."""
+        """
+        Write data to the server.
+
+        This method must terminate data with line ending.
+        """
 
     @abstractmethod
     async def readline(self) -> str | None:
-        """Reads a single line."""
+        """Reads a single line determined by line ending sequence."""

--- a/tsbot/connection/connection_types/raw_connection.py
+++ b/tsbot/connection/connection_types/raw_connection.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+
+from tsbot import parsers
+from tsbot.connection.connection_types import abc
+
+
+class RawConnection(abc.Connection):
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        address: str,
+        port: int,
+    ) -> None:
+        self._username = username
+        self._password = password
+        self._address = address
+        self._port = port
+
+        self._writer: asyncio.StreamWriter | None = None
+        self._reader: asyncio.StreamReader | None = None
+
+    async def connect(self) -> None:
+        self._reader, self._writer = await asyncio.open_connection(self._address, self._port)
+
+    async def validate_header(self) -> None:
+        if (data := await self.readline()) and data != "TS3\n\r":
+            raise ConnectionAbortedError("Invalid TeamSpeak server")
+        await self.readline()
+
+    async def authenticate(self) -> None:
+        await self.write(f"login {self._username} {self._password}")
+
+        data = await self.readline()
+        if data is None:
+            raise ConnectionAbortedError
+
+        resp = parsers.parse_line(data.rstrip().removeprefix("error "))
+        if resp["id"] != "0":
+            raise ConnectionAbortedError(resp["msg"])
+
+    def close(self) -> None:
+        if self._writer:
+            self._writer.close()
+
+    async def wait_closed(self) -> None:
+        if not self._writer:
+            raise ConnectionError("Trying to wait on uninitialized connection")
+
+        await self._writer.wait_closed()
+
+    async def write(self, data: str) -> None:
+        if not self._writer or self._writer.is_closing():
+            raise BrokenPipeError("Trying to write on a closed connection")
+
+        self._writer.write(f"{data}\n\r".encode())
+        await self._writer.drain()
+
+    async def readline(self) -> str | None:
+        if not self._reader:
+            raise ConnectionResetError("Reading on a closed connection")
+
+        try:
+            return (await self._reader.readuntil(b"\n\r")).decode()
+        except Exception:
+            return None

--- a/tsbot/connection/connection_types/raw_connection.py
+++ b/tsbot/connection/connection_types/raw_connection.py
@@ -39,7 +39,9 @@ class RawConnection(abc.Connection):
 
         resp = parsers.parse_line(data.rstrip().removeprefix("error "))
         if resp["id"] != "0":
-            raise ConnectionAbortedError(resp["msg"])
+            raise ConnectionAbortedError(
+                "".join((resp["msg"], f" ({extra})" if (extra := resp.get("extra_msg")) else ""))
+            )
 
     def close(self) -> None:
         if self._writer:

--- a/tsbot/connection/connection_types/ssh_connection.py
+++ b/tsbot/connection/connection_types/ssh_connection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncssh
 
 from tsbot.connection.connection_types import abc

--- a/tsbot/connection/connection_types/ssh_connection.py
+++ b/tsbot/connection/connection_types/ssh_connection.py
@@ -64,13 +64,10 @@ class SSHConnection(abc.Connection):
         await self._writer.drain()
 
     async def readline(self) -> str | None:
-        return await self.readuntil("\n\r")
-
-    async def readuntil(self, separator: str) -> str | None:
         if not self._reader:
             raise ConnectionResetError("Reading on a closed connection")
 
         try:
-            return await self._reader.readuntil(separator)
+            return await self._reader.readuntil("\n\r")
         except Exception:
             return None


### PR DESCRIPTION
If your server has SSH connections disabled for what ever reason or no encryption is needed, raw connections can suit your needs.

Configuring TSBot to use raw connection:
```python
bot = TSBot(
    username="USERNAME",
    password="PASSWORD",
    address="ADDRESS",
    port=10011  # important! default port = 10022 (ssh)
    protocol="raw",
)
```

Personally I still prefer SSH over raw connection, but more options is good for users.
SSH connections are still the default behavior.

Closes #54 