### PR TITLE
Tasks exceptions

### DIFF
--- a/docs/source/tasks.md
+++ b/docs/source/tasks.md
@@ -1,6 +1,15 @@
 # Tasks
 
-Tasks are a great way to schedule coroutines to be run outside your event/command handler.  
+Tasks are a great way to schedule coroutines to be run outside your event/command handler.
+
+```{warning}
+Task handlers should be well behaved. Tasks handlers can be cancelled at any point.
+This mainly happens when the bot is closing and cleaning up running tasks.
+You should never block task cancelling by catching [asyncio.CancelledError](asyncio.CancelledError) and ignoring it.
+This will hang your bot on close.
+If you need to do clean up in your task, catch the [asyncio.CancelledError](asyncio.CancelledError), do clean up, and return or re raise the exception.
+```
+
 Tasks handlers have one argument, the instance of [TSBot](tsbot.bot.TSBot).
 
 ```python

--- a/tsbot/tasks/task.py
+++ b/tsbot/tasks/task.py
@@ -24,10 +24,7 @@ def every(every_handler: TTaskHandler, seconds: float) -> TTaskHandler:
     @functools.wraps(every_handler)
     async def every_wrapper(bot: bot.TSBot) -> None:
         while True:
-            try:
-                await asyncio.sleep(seconds)
-                await every_handler(bot)
-            except asyncio.CancelledError:
-                break
+            await asyncio.sleep(seconds)
+            await every_handler(bot)
 
     return every_wrapper


### PR DESCRIPTION
Previously tasks that raised exceptions would pass silently.
This made debugging them harder than it should be.

This PR alleviates such pain points and logs the raised exceptions.