### PR TITLE
Typing extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,11 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
 ]
-dependencies = ["asyncssh == 2.17.0", "tsformatter >= 0.2.1"]
+dependencies = [
+    "asyncssh == 2.17.0",
+    "tsformatter >= 0.2.1",
+    "typing_extensions >= 4.12.2",
+]
 license = { file = "LICENSE" }
 urls = { repository = "https://github.com/jykob/tsbot", documentation = "https://tsbot.readthedocs.io/" }
 
@@ -47,6 +51,7 @@ package-data = { tsbot = ["py.typed"] }
 
 [tool.pyright]
 typeCheckingMode = "strict"
+
 
 [tool.ruff]
 line-length = 100

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -109,18 +109,22 @@ class TSBot:
 
     @property
     def uid(self) -> str:
+        """Bots UID"""
         return self._bot_info.uid
 
     @property
     def clid(self) -> str:
+        """Bots current client id"""
         return self._bot_info.clid
 
     @property
     def cldbid(self) -> str:
+        """Bots client database id"""
         return self._bot_info.cldbid
 
     @property
     def connected(self) -> bool:
+        """Is the bot currently connected to a server"""
         return self._connection.connected
 
     def _init(self) -> None:

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, Literal, NamedTuple, ParamSpec
+from typing import TYPE_CHECKING, Any, Concatenate, Literal, NamedTuple, ParamSpec, overload
+
+from typing_extensions import deprecated
 
 from tsbot import (
     commands,
@@ -156,6 +158,15 @@ class TSBot:
         """
         self._event_handler.add_event(event)
 
+    @overload
+    @deprecated("'ready' event is deprecated. Use 'connect' instead")
+    def on(
+        self, event_type: Literal["ready"]
+    ) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+
+    @overload
+    def on(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+
     def on(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]:
         """
         Decorator to register event handlers.
@@ -168,6 +179,17 @@ class TSBot:
             return func
 
         return event_decorator
+
+    @overload
+    @deprecated("'ready' event is deprecated. Use 'connect' instead")
+    def register_event_handler(
+        self, event_type: Literal["ready"], handler: events.TEventHandler
+    ) -> events.TSEventHandler: ...
+
+    @overload
+    def register_event_handler(
+        self, event_type: str, handler: events.TEventHandler
+    ) -> events.TSEventHandler: ...
 
     def register_event_handler(
         self, event_type: str, handler: events.TEventHandler
@@ -184,6 +206,15 @@ class TSBot:
         self._event_handler.register_event_handler(event_handler)
         return event_handler
 
+    @overload
+    @deprecated("'ready' event is deprecated. Use 'connect' instead")
+    def once(
+        self, event_type: Literal["ready"]
+    ) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+
+    @overload
+    def once(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+
     def once(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]:
         """
         Decorator to register once handler.
@@ -196,6 +227,17 @@ class TSBot:
             return func
 
         return once_decorator
+
+    @overload
+    @deprecated("'ready' event is deprecated. Use 'connect' instead")
+    def register_once_handler(
+        self, event_type: Literal["ready"], handler: events.TEventHandler
+    ) -> events.TSEventOnceHandler: ...
+
+    @overload
+    def register_once_handler(
+        self, event_type: str, handler: events.TEventHandler
+    ) -> events.TSEventOnceHandler: ...
 
     def register_once_handler(
         self, event_type: str, handler: events.TEventHandler

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -18,6 +18,7 @@ from tsbot import (
     ratelimiter,
     response,
     tasks,
+    utils,
 )
 
 if TYPE_CHECKING:
@@ -174,6 +175,8 @@ class TSBot:
         :param event_type: Name of the event.
         """
 
+        utils.check_for_deprecated_event(event_type)
+
         def event_decorator(func: events.TEventHandler) -> events.TEventHandler:
             self.register_event_handler(event_type, func)
             return func
@@ -202,6 +205,8 @@ class TSBot:
         :return: The instance of :class:`TSEventHandler<tsbot.events.TSEventHandler>` created.
         """
 
+        utils.check_for_deprecated_event(event_type)
+
         event_handler = events.TSEventHandler(event_type, handler)
         self._event_handler.register_event_handler(event_handler)
         return event_handler
@@ -221,6 +226,8 @@ class TSBot:
 
         :param event_type: Name of the event.
         """
+
+        utils.check_for_deprecated_event(event_type)
 
         def once_decorator(func: events.TEventHandler) -> events.TEventHandler:
             self.register_once_handler(event_type, func)
@@ -249,6 +256,8 @@ class TSBot:
         :param handler: Async function to handle the event.
         :return: The instance of :class:`TSEventOnceHandler<tsbot.events.TSEventOnceHandler>` created.
         """
+
+        utils.check_for_deprecated_event(event_type)
 
         event_handler = events.TSEventOnceHandler(event_type, handler, self._event_handler)
         self._event_handler.register_event_handler(event_handler)

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -483,10 +483,10 @@ class TSBot:
                     self.register_command(handler=member, **command_kwargs)
 
                 elif event_kwargs := getattr(member, "__ts_event__", None):
-                    self.register_event_handler(handler=member, **event_kwargs)
+                    self.register_event_handler(handler=member, **event_kwargs)  # type: ignore  #TODO: REMOVE
 
                 elif once_kwargs := getattr(member, "__ts_once__", None):
-                    self.register_once_handler(handler=member, **once_kwargs)
+                    self.register_once_handler(handler=member, **once_kwargs)  # type: ignore  #TODO: REMOVE
 
             self.plugins[plugin_to_be_loaded.__class__.__name__] = plugin_to_be_loaded
 

--- a/tsbot/events/event.py
+++ b/tsbot/events/event.py
@@ -12,7 +12,7 @@ class TSEvent(NamedTuple):
     ctx: Any
 
     @classmethod
-    def from_server_notification(cls: type[Self], raw_data: str) -> Self:
+    def from_server_notification(cls, raw_data: str) -> Self:
         """
         Creates a TSEvent instance from server notify
 

--- a/tsbot/events/event.py
+++ b/tsbot/events/event.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, NamedTuple, TypeVar
+from typing import Any, NamedTuple
+
+from typing_extensions import Self
 
 from tsbot import context, parsers
-
-_T = TypeVar("_T", bound="TSEvent")
 
 
 class TSEvent(NamedTuple):
@@ -12,7 +12,7 @@ class TSEvent(NamedTuple):
     ctx: Any
 
     @classmethod
-    def from_server_notification(cls: type[_T], raw_data: str) -> _T:
+    def from_server_notification(cls: type[Self], raw_data: str) -> Self:
         """
         Creates a TSEvent instance from server notify
 

--- a/tsbot/events/handler.py
+++ b/tsbot/events/handler.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-import warnings
 from collections import defaultdict
-from pathlib import Path  # type: ignore
 from typing import TYPE_CHECKING
 
 from tsbot import logging, utils
@@ -54,19 +51,6 @@ class EventHandler:
 
     def register_event_handler(self, event_handler: events.TSEventHandler) -> None:
         """Registers event handlers that will be called when given event happens."""
-
-        if event_handler.event == "ready":  # TODO: remove when 'ready' event deprecated
-            kwargs = (
-                dict(skip_file_prefixes=(str(Path(__file__).parent.parent),))
-                if sys.version_info >= (3, 12, 0)
-                else dict(stacklevel=4)
-            )
-
-            warnings.warn(
-                "'ready' event is deprecated. Use 'connect' instead",
-                DeprecationWarning,
-                **kwargs,  # type: ignore
-            )
 
         self._event_handlers[event_handler.event].append(event_handler)
 

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Coroutine
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Concatenate,
-    ParamSpec,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypeVar, overload
+
+from typing_extensions import deprecated
+
 
 if TYPE_CHECKING:
     from tsbot import bot, context
@@ -52,6 +49,25 @@ def command(
     return command_decorator
 
 
+@overload
+@deprecated("'ready' event is deprecated. Use 'connect' instead")
+def on(
+    event_type: Literal["ready"],
+) -> Callable[
+    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
+    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
+]: ...
+
+
+@overload
+def on(
+    event_type: str,
+) -> Callable[
+    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
+    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
+]: ...
+
+
 def on(
     event_type: str,
 ) -> Callable[
@@ -74,6 +90,25 @@ def on(
         return func
 
     return event_decorator
+
+
+@overload
+@deprecated("'ready' event is deprecated. Use 'connect' instead")
+def once(
+    event_type: Literal["ready"],
+) -> Callable[
+    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
+    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
+]: ...
+
+
+@overload
+def once(
+    event_type: str,
+) -> Callable[
+    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
+    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
+]: ...
 
 
 def once(

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypeVar, overload
 
 from typing_extensions import deprecated
 
+from tsbot import utils
 
 if TYPE_CHECKING:
     from tsbot import bot, context
@@ -76,12 +76,7 @@ def on(
 ]:
     """Decorator to register plugin events"""
 
-    if event_type == "ready":  # TODO: remove when 'ready' event deprecated
-        warnings.warn(
-            "'ready' event is deprecated. Use 'connect' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    utils.check_for_deprecated_event(event_type)
 
     def event_decorator(
         func: Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
@@ -119,12 +114,7 @@ def once(
 ]:
     """Decorator to register plugin events to be ran only once"""
 
-    if event_type == "ready":  # TODO: remove when 'ready' event deprecated
-        warnings.warn(
-            "'ready' event is deprecated. Use 'connect' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    utils.check_for_deprecated_event(event_type)
 
     def once_decorator(
         func: Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],

--- a/tsbot/query_builder/builder.py
+++ b/tsbot/query_builder/builder.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, Protocol, TypeVar
+from typing import TYPE_CHECKING, Protocol
+
+from typing_extensions import Self
 
 from tsbot import encoders
 
 if TYPE_CHECKING:
     from tsbot import query_builder
-
-
-_T = TypeVar("_T", bound="TSQuery")
 
 
 class Stringable(Protocol):
@@ -61,7 +60,7 @@ class TSQuery:
     def __repr__(self) -> str:
         return f"{self.__class__.__qualname__}({self._command!r})"
 
-    def option(self: _T, *args: Stringable) -> _T:
+    def option(self, *args: Stringable) -> Self:
         """
         Add options to the command eg. ``-groups``.
 
@@ -76,7 +75,7 @@ class TSQuery:
             self._parameter_blocks,
         )
 
-    def params(self: _T, **kwargs: Stringable) -> _T:
+    def params(self, **kwargs: Stringable) -> Self:
         """
         Add parameters to the command eg. ``cldbid=12``.
 
@@ -92,11 +91,8 @@ class TSQuery:
         )
 
     def param_block(
-        self: _T,
-        blocks: Iterable[Mapping[str, Stringable]] | None = None,
-        /,
-        **kwargs: Stringable,
-    ) -> _T:
+        self, blocks: Iterable[Mapping[str, Stringable]] | None = None, /, **kwargs: Stringable
+    ) -> Self:
         """
         Add parameter blocks eg. ``clid=1 | clid=2 | clid=3`` to the command.
         Takes in either an iterable of parameters in form of dict[str, Stringable]

--- a/tsbot/response.py
+++ b/tsbot/response.py
@@ -32,7 +32,7 @@ class TSResponse:
         return self.data[-1]
 
     @classmethod
-    def from_server_response(cls: type[Self], raw_data: Sequence[str]) -> Self:
+    def from_server_response(cls, raw_data: Sequence[str]) -> Self:
         response_info = parsers.parse_line(raw_data[-1].removeprefix("error "))
         data = parsers.parse_data("".join(raw_data[:-1]))
 

--- a/tsbot/response.py
+++ b/tsbot/response.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass
-from typing import TypeVar
+
+from typing_extensions import Self
 
 from tsbot import parsers
-
-_T = TypeVar("_T", bound="TSResponse")
 
 
 @dataclass(slots=True, frozen=True)
@@ -33,7 +32,7 @@ class TSResponse:
         return self.data[-1]
 
     @classmethod
-    def from_server_response(cls: type[_T], raw_data: Sequence[str]) -> _T:
+    def from_server_response(cls: type[Self], raw_data: Sequence[str]) -> Self:
         response_info = parsers.parse_line(raw_data[-1].removeprefix("error "))
         data = parsers.parse_data("".join(raw_data[:-1]))
 

--- a/tsbot/utils.py
+++ b/tsbot/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
@@ -12,3 +13,12 @@ def toggle(obj: object, attr: str, enter: Any, exit: Any) -> Generator[None, Non
         yield
     finally:
         setattr(obj, attr, exit)
+
+
+def check_for_deprecated_event(event_type: str):
+    if event_type == "ready":
+        warnings.warn(
+            "'ready' event is deprecated. Use 'connect' instead",
+            DeprecationWarning,
+            stacklevel=3,
+        )


### PR DESCRIPTION
Since Python 3.10, there has been some great typing improvements.
Typing extensions backports some useful typing related from newer versions of Python.

This PR implements such improvements:
- Typehint deprecated `ready` event.
- `Self` type.
- `@override` decorators to make sure correct method is being overridden
