### PR TITLE
Commands/Events typing

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -161,7 +161,7 @@ async def test_checks(
     monkeypatch.setattr(command, "handler", mock_handler)
 
     mock_check = mock.AsyncMock()
-    command.checks.append(mock_check)
+    command.checks = (mock_check,)
 
     command_context = context.TSCtx(
         {
@@ -192,7 +192,7 @@ async def test_checks_failing(
     mock_handler = mock.AsyncMock()
     monkeypatch.setattr(command, "handler", mock_handler)
 
-    command.checks.append(check)
+    command.checks = (check,)
 
     command_context = context.TSCtx(
         {

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -165,12 +165,26 @@ class TSBot:
     @deprecated("'ready' event is deprecated. Use 'connect' instead")
     def on(
         self, event_type: Literal["ready"]
-    ) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+    ) -> Callable[[events.TEventHandler[None]], events.TEventHandler[None]]: ...
 
     @overload
-    def on(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+    def on(
+        self, event_type: Literal["run", "connect", "disconnect", "reconnect", "close"]
+    ) -> Callable[[events.TEventHandler[None]], events.TEventHandler[None]]: ...
 
-    def on(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]:
+    @overload
+    def on(
+        self, event_type: Literal["send", "command_error", "permission_error", "parameter_error"]
+    ) -> Callable[[events.TEventHandler[context.TSCtx]], events.TEventHandler[context.TSCtx]]: ...
+
+    @overload
+    def on(
+        self, event_type: str
+    ) -> Callable[[events.TEventHandler[Any]], events.TEventHandler[Any]]: ...
+
+    def on(
+        self, event_type: str
+    ) -> Callable[[events.TEventHandler[Any]], events.TEventHandler[Any]]:
         """
         Decorator to register event handlers.
 
@@ -179,7 +193,7 @@ class TSBot:
 
         utils.check_for_deprecated_event(event_type)
 
-        def event_decorator(func: events.TEventHandler) -> events.TEventHandler:
+        def event_decorator(func: events.TEventHandler[Any]) -> events.TEventHandler[Any]:
             self.register_event_handler(event_type, func)
             return func
 
@@ -188,16 +202,30 @@ class TSBot:
     @overload
     @deprecated("'ready' event is deprecated. Use 'connect' instead")
     def register_event_handler(
-        self, event_type: Literal["ready"], handler: events.TEventHandler
+        self, event_type: Literal["ready"], handler: events.TEventHandler[None]
     ) -> events.TSEventHandler: ...
 
     @overload
     def register_event_handler(
-        self, event_type: str, handler: events.TEventHandler
+        self,
+        event_type: Literal["run", "connect", "disconnect", "reconnect", "close"],
+        handler: events.TEventHandler[None],
+    ) -> events.TSEventHandler: ...
+
+    @overload
+    def register_event_handler(
+        self,
+        event_type: Literal["send", "command_error", "permission_error", "parameter_error"],
+        handler: events.TEventHandler[context.TSCtx],
+    ) -> events.TSEventHandler: ...
+
+    @overload
+    def register_event_handler(
+        self, event_type: str, handler: events.TEventHandler[Any]
     ) -> events.TSEventHandler: ...
 
     def register_event_handler(
-        self, event_type: str, handler: events.TEventHandler
+        self, event_type: str, handler: events.TEventHandler[Any]
     ) -> events.TSEventHandler:
         """
         Register an event handler to be ran on an event.
@@ -217,12 +245,26 @@ class TSBot:
     @deprecated("'ready' event is deprecated. Use 'connect' instead")
     def once(
         self, event_type: Literal["ready"]
-    ) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+    ) -> Callable[[events.TEventHandler[None]], events.TEventHandler[None]]: ...
 
     @overload
-    def once(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+    def once(
+        self, event_type: Literal["run", "connect", "disconnect", "reconnect", "close"]
+    ) -> Callable[[events.TEventHandler[None]], events.TEventHandler[None]]: ...
 
-    def once(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]:
+    @overload
+    def once(
+        self, event_type: Literal["send", "command_error", "permission_error", "parameter_error"]
+    ) -> Callable[[events.TEventHandler[context.TSCtx]], events.TEventHandler[context.TSCtx]]: ...
+
+    @overload
+    def once(
+        self, event_type: str
+    ) -> Callable[[events.TEventHandler[Any]], events.TEventHandler[Any]]: ...
+
+    def once(
+        self, event_type: str
+    ) -> Callable[[events.TEventHandler[Any]], events.TEventHandler[Any]]:
         """
         Decorator to register once handler.
 
@@ -231,7 +273,7 @@ class TSBot:
 
         utils.check_for_deprecated_event(event_type)
 
-        def once_decorator(func: events.TEventHandler) -> events.TEventHandler:
+        def once_decorator(func: events.TEventHandler[Any]) -> events.TEventHandler[Any]:
             self.register_once_handler(event_type, func)
             return func
 
@@ -240,16 +282,30 @@ class TSBot:
     @overload
     @deprecated("'ready' event is deprecated. Use 'connect' instead")
     def register_once_handler(
-        self, event_type: Literal["ready"], handler: events.TEventHandler
+        self, event_type: Literal["ready"], handler: events.TEventHandler[None]
     ) -> events.TSEventOnceHandler: ...
 
     @overload
     def register_once_handler(
-        self, event_type: str, handler: events.TEventHandler
+        self,
+        event_type: Literal["run", "connect", "disconnect", "reconnect", "close"],
+        handler: events.TEventHandler[None],
+    ) -> events.TSEventOnceHandler: ...
+
+    @overload
+    def register_once_handler(
+        self,
+        event_type: Literal["send", "command_error", "permission_error", "parameter_error"],
+        handler: events.TEventHandler[context.TSCtx],
+    ) -> events.TSEventOnceHandler: ...
+
+    @overload
+    def register_once_handler(
+        self, event_type: str, handler: events.TEventHandler[Any]
     ) -> events.TSEventOnceHandler: ...
 
     def register_once_handler(
-        self, event_type: str, handler: events.TEventHandler
+        self, event_type: str, handler: events.TEventHandler[Any]
     ) -> events.TSEventOnceHandler:
         """
         Register an event handler to be ran once on an event.

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, Literal, NamedTuple, ParamSpec, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, ParamSpec, cast, overload
 
 from typing_extensions import deprecated
 
@@ -483,14 +483,20 @@ class TSBot:
 
         for plugin_to_be_loaded in plugins:
             for _, member in inspect.getmembers(plugin_to_be_loaded):
-                if command_kwargs := getattr(member, "__ts_command__", None):
-                    self.register_command(handler=member, **command_kwargs)
+                if command_kwargs := getattr(member, plugin.COMMAND_ATTR, None):
+                    self.register_command(
+                        handler=member, **cast(plugin.TCommandKwargs, command_kwargs)
+                    )
 
-                elif event_kwargs := getattr(member, "__ts_event__", None):
-                    self.register_event_handler(handler=member, **event_kwargs)  # type: ignore  #TODO: REMOVE
+                elif event_kwargs := getattr(member, plugin.EVENT_ATTR, None):
+                    self.register_event_handler(
+                        handler=member, **cast(plugin.TEventKwargs, event_kwargs)
+                    )
 
-                elif once_kwargs := getattr(member, "__ts_once__", None):
-                    self.register_once_handler(handler=member, **once_kwargs)  # type: ignore  #TODO: REMOVE
+                elif once_kwargs := getattr(member, plugin.ONCE_ATTR, None):
+                    self.register_once_handler(
+                        handler=member, **cast(plugin.TEventKwargs, once_kwargs)
+                    )
 
             self.plugins[plugin_to_be_loaded.__class__.__name__] = plugin_to_be_loaded
 

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Callable, Coroutine, Sequence
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, ParamSpec, cast, overload
+from typing import Any, Literal, NamedTuple, ParamSpec, cast, overload
 
 from typing_extensions import deprecated
 
@@ -14,15 +14,13 @@ from tsbot import (
     default_plugins,
     enums,
     events,
+    plugin,
     query_builder,
     ratelimiter,
     response,
     tasks,
     utils,
 )
-
-if TYPE_CHECKING:
-    from tsbot import plugin
 
 _P = ParamSpec("_P")
 

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -336,7 +336,7 @@ class TSBot:
         help_text: str = "",
         raw: bool = False,
         hidden: bool = False,
-        checks: Sequence[commands.TCommandHandler[_P]] | None = None,
+        checks: Sequence[commands.TCommandHandler[_P]] = (),
     ) -> Callable[[commands.TCommandHandler[_P]], commands.TCommandHandler[_P]]:
         """
         Decorator to register command handlers.
@@ -369,7 +369,7 @@ class TSBot:
         help_text: str = "",
         raw: bool = False,
         hidden: bool = False,
-        checks: Sequence[commands.TCommandHandler[_P]] | None = None,
+        checks: Sequence[commands.TCommandHandler[_P]] = (),
     ) -> commands.TSCommand:
         """
         Register command handler to be ran on specific command.
@@ -391,7 +391,7 @@ class TSBot:
             help_text,
             raw,
             hidden,
-            tuple(checks) if checks is not None else (),
+            tuple(checks),
         )
         self._command_handler.register_command(command_handler)
         return command_handler

--- a/tsbot/commands/__init__.py
+++ b/tsbot/commands/__init__.py
@@ -1,4 +1,4 @@
-from tsbot.commands.command import TSCommand
+from tsbot.commands.command import TCommandHandler, TSCommand
 from tsbot.commands.handler import CommandHandler
 
-__all__ = ("TSCommand", "CommandHandler")
+__all__ = ("TSCommand", "CommandHandler", "TCommandHandler")

--- a/tsbot/commands/command.py
+++ b/tsbot/commands/command.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from collections.abc import Callable, Coroutine
+from collections.abc import Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Concatenate, ParamSpec
+from typing import TYPE_CHECKING, ParamSpec, Protocol
 
 from tsbot import exceptions, parsers
 
@@ -15,9 +15,15 @@ if TYPE_CHECKING:
 _P = ParamSpec("_P")
 
 
-TCommandHandler = Callable[
-    Concatenate["bot.TSBot", "context.TSCtx", _P], Coroutine[None, None, None]
-]
+class TCommandHandler(Protocol[_P]):
+    def __call__(
+        self,
+        bot: bot.TSBot,
+        ctx: context.TSCtx,
+        /,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Coroutine[None, None, None]: ...
 
 
 @dataclass(slots=True)

--- a/tsbot/events/event_handler.py
+++ b/tsbot/events/event_handler.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from tsbot import bot, events
 
 
-TEventHandler = Callable[["bot.TSBot", Any], Coroutine[None, None, None]]
+_TC = TypeVar("_TC", contravariant=True)
+
+
+class TEventHandler(Protocol[_TC]):
+    def __call__(self, bot: bot.TSBot, ctx: _TC, /) -> Coroutine[None, None, None]: ...
 
 
 @dataclass(slots=True)
 class TSEventHandler:
     event: str
-    handler: TEventHandler
+    handler: TEventHandler[Any]
 
     async def run(self, bot: bot.TSBot, event: events.TSEvent) -> None:
         await self.handler(bot, event.ctx)

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypedDict, TypeVar, overload
 
 from typing_extensions import deprecated
 
@@ -13,9 +13,25 @@ if TYPE_CHECKING:
 _T = TypeVar("_T", bound="TSPlugin")
 _P = ParamSpec("_P")
 
+COMMAND_ATTR = "__ts_command__"
+EVENT_ATTR = "__ts_event__"
+ONCE_ATTR = "__ts_once__"
+
 
 class TSPlugin:
     """Base class for plugins"""
+
+
+class TCommandKwargs(TypedDict):
+    command: tuple[str, ...]
+    help_text: str
+    raw: bool
+    hidden: bool
+    checks: tuple[TCommandHandler[...], ...]
+
+
+class TEventKwargs(TypedDict):
+    event_type: str
 
 
 def command(
@@ -116,10 +132,7 @@ def once(
 
     utils.check_for_deprecated_event(event_type)
 
-    def once_decorator(
-        func: Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-    ) -> Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]:
-        setattr(func, "__ts_once__", {"event_type": event_type})
+        setattr(func, ONCE_ATTR, TEventKwargs(event_type=event_type))
         return func
 
     return once_decorator

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine, Sequence
-from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypedDict, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Literal, ParamSpec, Protocol, TypedDict, TypeVar, overload
 
 from typing_extensions import deprecated
 
@@ -12,13 +12,25 @@ if TYPE_CHECKING:
     from tsbot.commands import TCommandHandler
 
 
-_T = TypeVar("_T", bound="TSPlugin")
+_T = TypeVar("_T", bound="TSPlugin", contravariant=True)
+_TC = TypeVar("_TC", contravariant=True)
 _P = ParamSpec("_P")
 
-TPluginEventHandler = Callable[[_T, "bot.TSBot", Any], Coroutine[None, None, None]]
-TPluginCommandHandler = Callable[
-    Concatenate[_T, "bot.TSBot", "context.TSCtx", _P], Coroutine[None, None, None]
-]
+
+class TPluginCommandHandler(Protocol[_T, _P]):
+    def __call__(
+        self,
+        inst: _T,
+        bot: bot.TSBot,
+        ctx: context.TSCtx,
+        /,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Coroutine[None, None, None]: ...
+
+
+class TPluginEventHandler(Protocol[_T, _TC]):
+    def __call__(self, inst: _T, bot: bot.TSBot, ctx: _TC, /) -> Coroutine[None, None, None]: ...
 
 
 COMMAND_ATTR = "__ts_command__"

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -84,19 +84,27 @@ def command(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def on(
     event_type: Literal["ready"],
-) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]: ...
+) -> Callable[[TPluginEventHandler[_T, None]], TPluginEventHandler[_T, None]]: ...
 
 
 @overload
-def on(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]: ...
+def on(
+    event_type: Literal["run", "connect", "disconnect", "reconnect", "close"],
+) -> Callable[[TPluginEventHandler[_T, None]], TPluginEventHandler[_T, None]]: ...
 
 
-def on(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]:
+@overload
+def on(
+    event_type: Literal["send", "command_error", "permission_error", "parameter_error"],
+) -> Callable[[TPluginEventHandler[_T, context.TSCtx]], TPluginEventHandler[_T, context.TSCtx]]: ...
+
+
+def on(event_type: str) -> Callable[[TPluginEventHandler[_T, Any]], TPluginEventHandler[_T, Any]]:
     """Decorator to register plugin events"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def event_decorator(func: TPluginEventHandler[_T]) -> TPluginEventHandler[_T]:
+    def event_decorator(func: TPluginEventHandler[_T, Any]) -> TPluginEventHandler[_T, Any]:
         setattr(func, EVENT_ATTR, TEventKwargs(event_type=event_type))
         return func
 
@@ -107,19 +115,27 @@ def on(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandl
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def once(
     event_type: Literal["ready"],
-) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]: ...
+) -> Callable[[TPluginEventHandler[_T, None]], TPluginEventHandler[_T, None]]: ...
 
 
 @overload
-def once(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]: ...
+def once(
+    event_type: Literal["run", "connect", "disconnect", "reconnect", "close"],
+) -> Callable[[TPluginEventHandler[_T, None]], TPluginEventHandler[_T, None]]: ...
 
 
-def once(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]:
+@overload
+def once(
+    event_type: Literal["send", "command_error", "permission_error", "parameter_error"],
+) -> Callable[[TPluginEventHandler[_T, context.TSCtx]], TPluginEventHandler[_T, context.TSCtx]]: ...
+
+
+def once(event_type: str) -> Callable[[TPluginEventHandler[_T, Any]], TPluginEventHandler[_T, Any]]:
     """Decorator to register plugin events to be ran only once"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def once_decorator(func: TPluginEventHandler[_T]) -> TPluginEventHandler[_T]:
+    def once_decorator(func: TPluginEventHandler[_T, Any]) -> TPluginEventHandler[_T, Any]:
         setattr(func, ONCE_ATTR, TEventKwargs(event_type=event_type))
         return func
 

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -59,7 +59,7 @@ def command(
     help_text: str = "",
     raw: bool = False,
     hidden: bool = False,
-    checks: Sequence[TCommandHandler[_P]] | None = None,
+    checks: Sequence[TCommandHandler[_P]] = (),
 ) -> Callable[[TPluginCommandHandler[_T, _P]], TPluginCommandHandler[_T, _P]]:
     """Decorator to register plugin commands"""
 
@@ -72,7 +72,7 @@ def command(
                 help_text=help_text,
                 raw=raw,
                 hidden=hidden,
-                checks=tuple(checks) if checks is not None else (),
+                checks=tuple(checks),
             ),
         )
         return func

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Sequence
 from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypedDict, TypeVar, overload
 
 from typing_extensions import deprecated
@@ -9,9 +9,17 @@ from tsbot import utils
 
 if TYPE_CHECKING:
     from tsbot import bot, context
+    from tsbot.commands import TCommandHandler
+
 
 _T = TypeVar("_T", bound="TSPlugin")
 _P = ParamSpec("_P")
+
+TPluginEventHandler = Callable[[_T, "bot.TSBot", Any], Coroutine[None, None, None]]
+TPluginCommandHandler = Callable[
+    Concatenate[_T, "bot.TSBot", "context.TSCtx", _P], Coroutine[None, None, None]
+]
+
 
 COMMAND_ATTR = "__ts_command__"
 EVENT_ATTR = "__ts_event__"
@@ -39,26 +47,21 @@ def command(
     help_text: str = "",
     raw: bool = False,
     hidden: bool = False,
-    checks: list[Callable[..., Coroutine[None, None, None]]] | None = None,
-) -> Callable[
-    [Callable[Concatenate[_T, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]]],
-    Callable[Concatenate[_T, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]],
-]:
+    checks: Sequence[TCommandHandler[_P]] | None = None,
+) -> Callable[[TPluginCommandHandler[_T, _P]], TPluginCommandHandler[_T, _P]]:
     """Decorator to register plugin commands"""
 
-    def command_decorator(
-        func: Callable[Concatenate[_T, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]],
-    ) -> Callable[Concatenate[_T, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]]:
+    def command_decorator(func: TPluginCommandHandler[_T, _P]) -> TPluginCommandHandler[_T, _P]:
         setattr(
             func,
-            "__ts_command__",
-            {
-                "command": command,
-                "help_text": help_text,
-                "raw": raw,
-                "hidden": hidden,
-                "checks": checks or [],
-            },
+            COMMAND_ATTR,
+            TCommandKwargs(
+                command=command,
+                help_text=help_text,
+                raw=raw,
+                hidden=hidden,
+                checks=tuple(checks) if checks is not None else (),
+            ),
         )
         return func
 
@@ -69,35 +72,20 @@ def command(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def on(
     event_type: Literal["ready"],
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]: ...
+) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]: ...
 
 
 @overload
-def on(
-    event_type: str,
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]: ...
+def on(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]: ...
 
 
-def on(
-    event_type: str,
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]:
+def on(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]:
     """Decorator to register plugin events"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def event_decorator(
-        func: Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-    ) -> Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]:
-        setattr(func, "__ts_event__", {"event_type": event_type})
+    def event_decorator(func: TPluginEventHandler[_T]) -> TPluginEventHandler[_T]:
+        setattr(func, EVENT_ATTR, TEventKwargs(event_type=event_type))
         return func
 
     return event_decorator
@@ -107,31 +95,19 @@ def on(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def once(
     event_type: Literal["ready"],
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]: ...
+) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]: ...
 
 
 @overload
-def once(
-    event_type: str,
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]: ...
+def once(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]: ...
 
 
-def once(
-    event_type: str,
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]:
+def once(event_type: str) -> Callable[[TPluginEventHandler[_T]], TPluginEventHandler[_T]]:
     """Decorator to register plugin events to be ran only once"""
 
     utils.check_for_deprecated_event(event_type)
 
+    def once_decorator(func: TPluginEventHandler[_T]) -> TPluginEventHandler[_T]:
         setattr(func, ONCE_ATTR, TEventKwargs(event_type=event_type))
         return func
 


### PR DESCRIPTION
Commands have bit of a problem attached to them: typing.
Pythons typing system while good, lacks some features.

This PR improves:
- typesafety with commands.
- type overloads for built-in events.
- broadens commands checks from list to any sequence of check handlers.
- some internal type handling.
