### PR TITLE
Events typing

### DIFF
--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -24,6 +24,7 @@ from tsbot import (
 
 if TYPE_CHECKING:
     from tsbot import plugin
+    from tsbot.events import event_types
 
 _P = ParamSpec("_P")
 
@@ -156,12 +157,31 @@ class TSBot:
     @deprecated("'ready' event is deprecated. Use 'connect' instead")
     def on(
         self, event_type: Literal["ready"]
-    ) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+    ) -> Callable[[events.TEventHandler[None]], events.TEventHandler[None]]: ...
 
     @overload
-    def on(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+    def on(
+        self, event_type: event_types.BUILTIN_EVENTS
+    ) -> Callable[[events.TEventHandler[context.TSCtx]], events.TEventHandler[context.TSCtx]]: ...
 
-    def on(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]:
+    @overload
+    def on(
+        self, event_type: event_types.BUILTIN_NO_CTX_EVENTS
+    ) -> Callable[[events.TEventHandler[None]], events.TEventHandler[None]]: ...
+
+    @overload
+    def on(
+        self, event_type: event_types.TS_EVENTS
+    ) -> Callable[[events.TEventHandler[context.TSCtx]], events.TEventHandler[context.TSCtx]]: ...
+
+    @overload
+    def on(
+        self, event_type: str
+    ) -> Callable[[events.TEventHandler[Any]], events.TEventHandler[Any]]: ...
+
+    def on(
+        self, event_type: str
+    ) -> Callable[[events.TEventHandler[Any]], events.TEventHandler[Any]]:
         """
         Decorator to register event handlers.
 
@@ -170,7 +190,7 @@ class TSBot:
 
         utils.check_for_deprecated_event(event_type)
 
-        def event_decorator(func: events.TEventHandler) -> events.TEventHandler:
+        def event_decorator(func: events.TEventHandler[Any]) -> events.TEventHandler[Any]:
             self.register_event_handler(event_type, func)
             return func
 
@@ -179,16 +199,31 @@ class TSBot:
     @overload
     @deprecated("'ready' event is deprecated. Use 'connect' instead")
     def register_event_handler(
-        self, event_type: Literal["ready"], handler: events.TEventHandler
+        self, event_type: Literal["ready"], handler: events.TEventHandler[None]
     ) -> events.TSEventHandler: ...
 
     @overload
     def register_event_handler(
-        self, event_type: str, handler: events.TEventHandler
+        self, event_type: event_types.BUILTIN_EVENTS, handler: events.TEventHandler[context.TSCtx]
+    ) -> events.TSEventHandler: ...
+
+    @overload
+    def register_event_handler(
+        self, event_type: event_types.BUILTIN_NO_CTX_EVENTS, handler: events.TEventHandler[None]
+    ) -> events.TSEventHandler: ...
+
+    @overload
+    def register_event_handler(
+        self, event_type: event_types.TS_EVENTS, handler: events.TEventHandler[context.TSCtx]
+    ) -> events.TSEventHandler: ...
+
+    @overload
+    def register_event_handler(
+        self, event_type: str, handler: events.TEventHandler[Any]
     ) -> events.TSEventHandler: ...
 
     def register_event_handler(
-        self, event_type: str, handler: events.TEventHandler
+        self, event_type: str, handler: events.TEventHandler[Any]
     ) -> events.TSEventHandler:
         """
         Register an event handler to be ran on an event.
@@ -208,12 +243,31 @@ class TSBot:
     @deprecated("'ready' event is deprecated. Use 'connect' instead")
     def once(
         self, event_type: Literal["ready"]
-    ) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+    ) -> Callable[[events.TEventHandler[None]], events.TEventHandler[None]]: ...
 
     @overload
-    def once(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]: ...
+    def once(
+        self, event_type: event_types.BUILTIN_EVENTS
+    ) -> Callable[[events.TEventHandler[context.TSCtx]], events.TEventHandler[context.TSCtx]]: ...
 
-    def once(self, event_type: str) -> Callable[[events.TEventHandler], events.TEventHandler]:
+    @overload
+    def once(
+        self, event_type: event_types.BUILTIN_NO_CTX_EVENTS
+    ) -> Callable[[events.TEventHandler[None]], events.TEventHandler[None]]: ...
+
+    @overload
+    def once(
+        self, event_type: event_types.TS_EVENTS
+    ) -> Callable[[events.TEventHandler[context.TSCtx]], events.TEventHandler[context.TSCtx]]: ...
+
+    @overload
+    def once(
+        self, event_type: str
+    ) -> Callable[[events.TEventHandler[Any]], events.TEventHandler[Any]]: ...
+
+    def once(
+        self, event_type: str
+    ) -> Callable[[events.TEventHandler[Any]], events.TEventHandler[Any]]:
         """
         Decorator to register once handler.
 
@@ -222,7 +276,7 @@ class TSBot:
 
         utils.check_for_deprecated_event(event_type)
 
-        def once_decorator(func: events.TEventHandler) -> events.TEventHandler:
+        def once_decorator(func: events.TEventHandler[Any]) -> events.TEventHandler[Any]:
             self.register_once_handler(event_type, func)
             return func
 
@@ -231,16 +285,31 @@ class TSBot:
     @overload
     @deprecated("'ready' event is deprecated. Use 'connect' instead")
     def register_once_handler(
-        self, event_type: Literal["ready"], handler: events.TEventHandler
+        self, event_type: Literal["ready"], handler: events.TEventHandler[None]
     ) -> events.TSEventOnceHandler: ...
 
     @overload
     def register_once_handler(
-        self, event_type: str, handler: events.TEventHandler
+        self, event_type: event_types.BUILTIN_EVENTS, handler: events.TEventHandler[context.TSCtx]
+    ) -> events.TSEventOnceHandler: ...
+
+    @overload
+    def register_once_handler(
+        self, event_type: event_types.BUILTIN_NO_CTX_EVENTS, handler: events.TEventHandler[None]
+    ) -> events.TSEventOnceHandler: ...
+
+    @overload
+    def register_once_handler(
+        self, event_type: event_types.TS_EVENTS, handler: events.TEventHandler[context.TSCtx]
+    ) -> events.TSEventOnceHandler: ...
+
+    @overload
+    def register_once_handler(
+        self, event_type: str, handler: events.TEventHandler[Any]
     ) -> events.TSEventOnceHandler: ...
 
     def register_once_handler(
-        self, event_type: str, handler: events.TEventHandler
+        self, event_type: str, handler: events.TEventHandler[Any]
     ) -> events.TSEventOnceHandler:
         """
         Register an event handler to be ran once on an event.

--- a/tsbot/events/event_handler.py
+++ b/tsbot/events/event_handler.py
@@ -2,20 +2,22 @@ from __future__ import annotations
 
 from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from tsbot import bot, events
 
+_TC = TypeVar("_TC", contravariant=True)
 
-class TEventHandler(Protocol):
-    def __call__(self, bot: bot.TSBot, ctx: Any, /) -> Coroutine[None, None, None]: ...
+
+class TEventHandler(Protocol[_TC]):
+    def __call__(self, bot: bot.TSBot, ctx: _TC, /) -> Coroutine[None, None, None]: ...
 
 
 @dataclass(slots=True)
 class TSEventHandler:
     event: str
-    handler: TEventHandler
+    handler: TEventHandler[Any]
 
     async def run(self, bot: bot.TSBot, event: events.TSEvent) -> None:
         await self.handler(bot, event.ctx)

--- a/tsbot/events/event_handler.py
+++ b/tsbot/events/event_handler.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from tsbot import bot, events
 
 
-TEventHandler = Callable[["bot.TSBot", Any], Coroutine[None, None, None]]
+class TEventHandler(Protocol):
+    def __call__(self, bot: bot.TSBot, ctx: Any, /) -> Coroutine[None, None, None]: ...
 
 
 @dataclass(slots=True)

--- a/tsbot/events/event_types.py
+++ b/tsbot/events/event_types.py
@@ -31,5 +31,3 @@ TS_EVENTS = Literal[
     "channelpasswordchanged",
     "tokenused",
 ]
-
-ALL_EVENTS = BUILTIN_EVENTS | BUILTIN_NO_CTX_EVENTS | TS_EVENTS | str

--- a/tsbot/events/event_types.py
+++ b/tsbot/events/event_types.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Literal
+
+BUILTIN_NO_CTX_EVENTS = Literal[
+    "run",
+    "connect",
+    "disconnect",
+    "reconnect",
+    "close",
+]
+
+BUILTIN_EVENTS = Literal[
+    "send",
+    "command_error",
+    "permission_error",
+    "parameter_error",
+]
+
+TS_EVENTS = Literal[
+    "textmessage",
+    "cliententerview",
+    "clientleftview",
+    "serveredited",
+    "channeledited",
+    "channeldescriptionchanged",
+    "clientmoved",
+    "channelcreated",
+    "channeldeleted",
+    "channelmoved",
+    "channelpasswordchanged",
+    "tokenused",
+]
+
+ALL_EVENTS = BUILTIN_EVENTS | BUILTIN_NO_CTX_EVENTS | TS_EVENTS | str

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Concatenate, Literal, ParamSpec, Protocol, TypeVar, overload
 
 from typing_extensions import deprecated
 
@@ -10,8 +10,13 @@ from tsbot import utils
 if TYPE_CHECKING:
     from tsbot import bot, context
 
-_T = TypeVar("_T", bound="TSPlugin")
+_TP = TypeVar("_TP", bound="TSPlugin", contravariant=True)
+_TC = TypeVar("_TC", contravariant=True)
 _P = ParamSpec("_P")
+
+
+class TPluginEventHandler(Protocol[_TP]):
+    def __call__(self, inst: _TP, bot: bot.TSBot, ctx: Any, /) -> Coroutine[None, None, None]: ...
 
 
 class TSPlugin:
@@ -25,14 +30,14 @@ def command(
     hidden: bool = False,
     checks: list[Callable[..., Coroutine[None, None, None]]] | None = None,
 ) -> Callable[
-    [Callable[Concatenate[_T, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]]],
-    Callable[Concatenate[_T, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]],
+    [Callable[Concatenate[_TP, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]]],
+    Callable[Concatenate[_TP, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]],
 ]:
     """Decorator to register plugin commands"""
 
     def command_decorator(
-        func: Callable[Concatenate[_T, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]],
-    ) -> Callable[Concatenate[_T, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]]:
+        func: Callable[Concatenate[_TP, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]],
+    ) -> Callable[Concatenate[_TP, bot.TSBot, context.TSCtx, _P], Coroutine[None, None, None]]:
         setattr(
             func,
             "__ts_command__",
@@ -53,34 +58,23 @@ def command(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def on(
     event_type: Literal["ready"],
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]: ...
+) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]: ...
 
 
 @overload
 def on(
     event_type: str,
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]: ...
+) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]: ...
 
 
 def on(
     event_type: str,
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]:
+) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]:
     """Decorator to register plugin events"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def event_decorator(
-        func: Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-    ) -> Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]:
+    def event_decorator(func: TPluginEventHandler[_TP]) -> TPluginEventHandler[_TP]:
         setattr(func, "__ts_event__", {"event_type": event_type})
         return func
 
@@ -91,34 +85,23 @@ def on(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def once(
     event_type: Literal["ready"],
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]: ...
+) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]: ...
 
 
 @overload
 def once(
     event_type: str,
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]: ...
+) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]: ...
 
 
 def once(
     event_type: str,
-) -> Callable[
-    [Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-]:
+) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]:
     """Decorator to register plugin events to be ran only once"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def once_decorator(
-        func: Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]],
-    ) -> Callable[[_T, bot.TSBot, Any], Coroutine[None, None, None]]:
+    def once_decorator(func: TPluginEventHandler[_TP]) -> TPluginEventHandler[_TP]:
         setattr(func, "__ts_once__", {"event_type": event_type})
         return func
 

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -9,14 +9,15 @@ from tsbot import utils
 
 if TYPE_CHECKING:
     from tsbot import bot, context
+    from tsbot.events import event_types
 
 _TP = TypeVar("_TP", bound="TSPlugin", contravariant=True)
 _TC = TypeVar("_TC", contravariant=True)
 _P = ParamSpec("_P")
 
 
-class TPluginEventHandler(Protocol[_TP]):
-    def __call__(self, inst: _TP, bot: bot.TSBot, ctx: Any, /) -> Coroutine[None, None, None]: ...
+class TPluginEventHandler(Protocol[_TP, _TC]):
+    def __call__(self, inst: _TP, bot: bot.TSBot, ctx: _TC, /) -> Coroutine[None, None, None]: ...
 
 
 class TSPlugin:
@@ -58,23 +59,45 @@ def command(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def on(
     event_type: Literal["ready"],
-) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]: ...
+) -> Callable[[TPluginEventHandler[_TP, None]], TPluginEventHandler[_TP, None]]: ...
+
+
+@overload
+def on(
+    event_type: event_types.BUILTIN_EVENTS,
+) -> Callable[
+    [TPluginEventHandler[_TP, context.TSCtx]], TPluginEventHandler[_TP, context.TSCtx]
+]: ...
+
+
+@overload
+def on(
+    event_type: event_types.BUILTIN_NO_CTX_EVENTS,
+) -> Callable[[TPluginEventHandler[_TP, None]], TPluginEventHandler[_TP, None]]: ...
+
+
+@overload
+def on(
+    event_type: event_types.TS_EVENTS,
+) -> Callable[
+    [TPluginEventHandler[_TP, context.TSCtx]], TPluginEventHandler[_TP, context.TSCtx]
+]: ...
 
 
 @overload
 def on(
     event_type: str,
-) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]: ...
+) -> Callable[[TPluginEventHandler[_TP, Any]], TPluginEventHandler[_TP, Any]]: ...
 
 
 def on(
     event_type: str,
-) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]:
+) -> Callable[[TPluginEventHandler[_TP, Any]], TPluginEventHandler[_TP, Any]]:
     """Decorator to register plugin events"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def event_decorator(func: TPluginEventHandler[_TP]) -> TPluginEventHandler[_TP]:
+    def event_decorator(func: TPluginEventHandler[_TP, Any]) -> TPluginEventHandler[_TP, Any]:
         setattr(func, "__ts_event__", {"event_type": event_type})
         return func
 
@@ -85,23 +108,45 @@ def on(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def once(
     event_type: Literal["ready"],
-) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]: ...
+) -> Callable[[TPluginEventHandler[_TP, None]], TPluginEventHandler[_TP, None]]: ...
+
+
+@overload
+def once(
+    event_type: event_types.BUILTIN_EVENTS,
+) -> Callable[
+    [TPluginEventHandler[_TP, context.TSCtx]], TPluginEventHandler[_TP, context.TSCtx]
+]: ...
+
+
+@overload
+def once(
+    event_type: event_types.BUILTIN_NO_CTX_EVENTS,
+) -> Callable[[TPluginEventHandler[_TP, None]], TPluginEventHandler[_TP, None]]: ...
+
+
+@overload
+def once(
+    event_type: event_types.TS_EVENTS,
+) -> Callable[
+    [TPluginEventHandler[_TP, context.TSCtx]], TPluginEventHandler[_TP, context.TSCtx]
+]: ...
 
 
 @overload
 def once(
     event_type: str,
-) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]: ...
+) -> Callable[[TPluginEventHandler[_TP, Any]], TPluginEventHandler[_TP, Any]]: ...
 
 
 def once(
     event_type: str,
-) -> Callable[[TPluginEventHandler[_TP]], TPluginEventHandler[_TP]]:
+) -> Callable[[TPluginEventHandler[_TP, Any]], TPluginEventHandler[_TP, Any]]:
     """Decorator to register plugin events to be ran only once"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def once_decorator(func: TPluginEventHandler[_TP]) -> TPluginEventHandler[_TP]:
+    def once_decorator(func: TPluginEventHandler[_TP, Any]) -> TPluginEventHandler[_TP, Any]:
         setattr(func, "__ts_once__", {"event_type": event_type})
         return func
 

--- a/tsbot/query_builder/__init__.py
+++ b/tsbot/query_builder/__init__.py
@@ -1,8 +1,3 @@
-from typing import TYPE_CHECKING
-
 from tsbot.query_builder.builder import TSQuery, query
 
-if TYPE_CHECKING:
-    from tsbot.query_builder.commands import TCommands
-
-__all__ = ("query", "TSQuery", "TCommands")
+__all__ = ("query", "TSQuery")

--- a/tsbot/query_builder/builder.py
+++ b/tsbot/query_builder/builder.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 from tsbot import encoders
 
 if TYPE_CHECKING:
-    from tsbot import query_builder
+    from tsbot.query_builder import commands
 
 
 class Stringable(Protocol):
@@ -39,7 +39,7 @@ class TSQuery:
 
     def __init__(
         self,
-        command: query_builder.TCommands,
+        command: commands.TCommands,
         options: tuple[Stringable, ...] | None = None,
         parameters: dict[str, Stringable] | None = None,
         parameter_blocks: tuple[dict[str, Stringable], ...] | None = None,


### PR DESCRIPTION
Provide typing overloads for built-in and TeamSpeak events, and their context type.

![Code_01oTqvaV7h](https://github.com/user-attachments/assets/9654cf04-d7f4-44c1-868f-967fb901b07d)
