### PR TITLE
Task args

### DIFF
--- a/docs/source/tasks.md
+++ b/docs/source/tasks.md
@@ -1,16 +1,7 @@
 # Tasks
 
-Tasks are a great way to schedule coroutines to be run outside your event/command handler.
-
-```{warning}
-Task handlers should be well behaved. Tasks handlers can be cancelled at any point.
-This mainly happens when the bot is closing and cleaning up running tasks.
-You should never block task cancelling by catching [asyncio.CancelledError](asyncio.CancelledError) and ignoring it.
-This will hang your bot on close.
-If you need to do clean up in your task, catch the [asyncio.CancelledError](asyncio.CancelledError), do clean up, and return or re raise the exception.
-```
-
-Tasks handlers have one argument, the instance of [TSBot](tsbot.bot.TSBot).
+Tasks are a great way to schedule coroutines to be run outside your event/command handler.  
+Tasks are managed by TSBot and automatically cleaned up on done/closing.
 
 ```python
 async def example_task(bot: TSBot):
@@ -21,7 +12,7 @@ async def example_task(bot: TSBot):
 bot.register_task(example_task)
 ```
 
-if you need more arguments passed, you can use [functools.partial](functools.partial)
+You can pass arguments to your task by providing them to the [bot.register_task()](tsbot.bot.TSBot.register_task) method after the handler.
 
 ```python
 async def example_task(bot: TSBot, arg1: int, arg2: str):
@@ -29,11 +20,19 @@ async def example_task(bot: TSBot, arg1: int, arg2: str):
     # Do something with the bot
 
 
-bot.register_task(functools.partial(example_task, arg1=1, arg2="test"))
+bot.register_task(example_task, 1, "test")
 ```
 
 ```{warning}
-Tasks handling is started before the bot is connected to the server.
+Task handlers should be well behaved. Tasks can be cancelled at any point.
+This mainly happens when the bot is closing and cleaning up running tasks.
+You should never block task cancelling by catching [asyncio.CancelledError](asyncio.CancelledError) and ignoring it.
+This will hang your bot on close.
+If you need to do clean up in your task, catch the [asyncio.CancelledError](asyncio.CancelledError), do clean up, and return or re raise the exception.
+```
+
+```{warning}
+Task handling is started before the bot is connected to the server.
 If you need the bot to be connected to the TeamSpeak server, Use build-in
 `connect` [event](./events.md#built-in-events) event handlers to register tasks.
 ```

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,11 +25,11 @@ def running_task_manager(task_manager: tasks.TaskManager, mock_bot: bot.TSBot):
 
 @pytest.fixture
 def tstask():
-    async def task(bot: bot.TSBot):
+    async def task(bot: bot.TSBot) -> None:
         while True:
             await asyncio.sleep(0)
 
-    return tasks.TSTask(task)
+    return tasks.TSTask(task)  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -6,7 +6,7 @@ import inspect
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast, overload
 
-from typing_extensions import deprecated
+from typing_extensions import TypeVarTuple, Unpack, deprecated
 
 from tsbot import (
     commands,
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from tsbot.commands import CommandHandler, RawCommandHandler
     from tsbot.events import event_types
 
+_Ts = TypeVarTuple("_Ts")
 
 _DEFAULT_PORTS = {"ssh": 10022, "raw": 10011}
 
@@ -472,8 +473,8 @@ class TSBot:
 
     def register_task(
         self,
-        handler: tasks.TaskHandler,
-        *,
+        handler: tasks.TaskHandler[Unpack[_Ts]],
+        *args: Unpack[_Ts],
         name: str | None = None,
     ) -> tasks.TSTask:
         """
@@ -484,15 +485,15 @@ class TSBot:
         :return: Instance of :class:`TSTask<tsbot.tasks.TSTask>` created.
         """
 
-        task = tasks.TSTask(handler=handler, name=name)
+        task = tasks.TSTask(handler=handler, args=args, name=name)
         self._task_manager.register_task(self, task)
         return task
 
     def register_every_task(
         self,
         seconds: float,
-        handler: tasks.TaskHandler,
-        *,
+        handler: tasks.TaskHandler[Unpack[_Ts]],
+        *args: Unpack[_Ts],
         name: str | None = None,
     ) -> tasks.TSTask:
         """
@@ -503,7 +504,7 @@ class TSBot:
         :param name: Name of the task.
         :return: Instance of :class:`TSTask<tsbot.tasks.TSTask>` created.
         """
-        task = tasks.TSTask(handler=tasks.every(handler, seconds), name=name)
+        task = tasks.TSTask(handler=tasks.every(handler, seconds), args=args, name=name)
         self._task_manager.register_task(self, task)
         return task
 

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -470,6 +470,24 @@ class TSBot:
         """
         return self._command_manager.get_command(command)
 
+    def register_task(
+        self,
+        handler: tasks.TaskHandler,
+        *,
+        name: str | None = None,
+    ) -> tasks.TSTask:
+        """
+        Register task handler as a background task.
+
+        :param handler: Async function to be called when the task is executed.
+        :param name: Name of the task.
+        :return: Instance of :class:`TSTask<tsbot.tasks.TSTask>` created.
+        """
+
+        task = tasks.TSTask(handler=handler, name=name)
+        self._task_manager.register_task(self, task)
+        return task
+
     def register_every_task(
         self,
         seconds: float,
@@ -486,24 +504,6 @@ class TSBot:
         :return: Instance of :class:`TSTask<tsbot.tasks.TSTask>` created.
         """
         task = tasks.TSTask(handler=tasks.every(handler, seconds), name=name)
-        self._task_manager.register_task(self, task)
-        return task
-
-    def register_task(
-        self,
-        handler: tasks.TaskHandler,
-        *,
-        name: str | None = None,
-    ) -> tasks.TSTask:
-        """
-        Register task handler as a background task.
-
-        :param handler: Async function to be called when the task is executed.
-        :param name: Name of the task.
-        :return: Instance of :class:`TSTask<tsbot.tasks.TSTask>` created.
-        """
-
-        task = tasks.TSTask(handler=handler, name=name)
         self._task_manager.register_task(self, task)
         return task
 

--- a/tsbot/events/event_handler.py
+++ b/tsbot/events/event_handler.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 if TYPE_CHECKING:
     from tsbot import bot, events
 
-TC = TypeVar("TC", contravariant=True)
+_TC = TypeVar("_TC", contravariant=True)
 
 
-class EventHandler(Protocol[TC]):
-    def __call__(self, bot: bot.TSBot, ctx: TC, /) -> Coroutine[None, None, None]: ...
+class EventHandler(Protocol[_TC]):
+    def __call__(self, bot: bot.TSBot, ctx: _TC, /) -> Coroutine[None, None, None]: ...
 
 
 @dataclass(slots=True)

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -20,24 +20,24 @@ if TYPE_CHECKING:
     from tsbot.commands import CommandHandler
     from tsbot.events import event_types
 
-TP = TypeVar("TP", bound="TSPlugin", contravariant=True)
-TC = TypeVar("TC", contravariant=True)
+_TP = TypeVar("_TP", bound="TSPlugin", contravariant=True)
+_TC = TypeVar("_TC", contravariant=True)
 
 
-class PluginEventHandler(Protocol[TP, TC]):
-    def __call__(self, inst: TP, bot: bot.TSBot, ctx: TC, /) -> Coroutine[None, None, None]: ...
+class PluginEventHandler(Protocol[_TP, _TC]):
+    def __call__(self, inst: _TP, bot: bot.TSBot, ctx: _TC, /) -> Coroutine[None, None, None]: ...
 
 
-class PluginRawCommandHandler(Protocol[TP]):
+class PluginRawCommandHandler(Protocol[_TP]):
     def __call__(
-        self, inst: TP, bot: bot.TSBot, ctx: context.TSCtx, arg: str, /
+        self, inst: _TP, bot: bot.TSBot, ctx: context.TSCtx, arg: str, /
     ) -> Coroutine[None, None, None]: ...
 
 
-class PluginCommandHandler(Protocol[TP]):
+class PluginCommandHandler(Protocol[_TP]):
     def __call__(
         self,
-        inst: TP,
+        inst: _TP,
         bot: bot.TSBot,
         ctx: context.TSCtx,
         /,
@@ -74,7 +74,7 @@ def command(
     raw: Literal[True],
     hidden: bool = False,
     checks: Sequence[CommandHandler] = (),
-) -> Callable[[PluginRawCommandHandler[TP]], PluginRawCommandHandler[TP]]: ...
+) -> Callable[[PluginRawCommandHandler[_TP]], PluginRawCommandHandler[_TP]]: ...
 
 
 @overload
@@ -84,7 +84,7 @@ def command(
     raw: Literal[False] = False,
     hidden: bool = False,
     checks: Sequence[CommandHandler] = (),
-) -> Callable[[PluginCommandHandler[TP]], PluginCommandHandler[TP]]: ...
+) -> Callable[[PluginCommandHandler[_TP]], PluginCommandHandler[_TP]]: ...
 
 
 def command(
@@ -117,41 +117,41 @@ def command(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def on(
     event_type: Literal["ready"],
-) -> Callable[[PluginEventHandler[TP, None]], PluginEventHandler[TP, None]]: ...
+) -> Callable[[PluginEventHandler[_TP, None]], PluginEventHandler[_TP, None]]: ...
 
 
 @overload
 def on(
     event_type: event_types.BUILTIN_EVENTS,
-) -> Callable[[PluginEventHandler[TP, context.TSCtx]], PluginEventHandler[TP, context.TSCtx]]: ...
+) -> Callable[[PluginEventHandler[_TP, context.TSCtx]], PluginEventHandler[_TP, context.TSCtx]]: ...
 
 
 @overload
 def on(
     event_type: event_types.BUILTIN_NO_CTX_EVENTS,
-) -> Callable[[PluginEventHandler[TP, None]], PluginEventHandler[TP, None]]: ...
+) -> Callable[[PluginEventHandler[_TP, None]], PluginEventHandler[_TP, None]]: ...
 
 
 @overload
 def on(
     event_type: event_types.TS_EVENTS,
-) -> Callable[[PluginEventHandler[TP, context.TSCtx]], PluginEventHandler[TP, context.TSCtx]]: ...
+) -> Callable[[PluginEventHandler[_TP, context.TSCtx]], PluginEventHandler[_TP, context.TSCtx]]: ...
 
 
 @overload
 def on(
     event_type: str,
-) -> Callable[[PluginEventHandler[TP, Any]], PluginEventHandler[TP, Any]]: ...
+) -> Callable[[PluginEventHandler[_TP, Any]], PluginEventHandler[_TP, Any]]: ...
 
 
 def on(
     event_type: str,
-) -> Callable[[PluginEventHandler[TP, Any]], PluginEventHandler[TP, Any]]:
+) -> Callable[[PluginEventHandler[_TP, Any]], PluginEventHandler[_TP, Any]]:
     """Decorator to register plugin events"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def event_decorator(func: PluginEventHandler[TP, Any]) -> PluginEventHandler[TP, Any]:
+    def event_decorator(func: PluginEventHandler[_TP, Any]) -> PluginEventHandler[_TP, Any]:
         setattr(func, EVENT_ATTR, EventKwargs(event_type=event_type))
         return func
 
@@ -162,41 +162,41 @@ def on(
 @deprecated("'ready' event is deprecated. Use 'connect' instead")
 def once(
     event_type: Literal["ready"],
-) -> Callable[[PluginEventHandler[TP, None]], PluginEventHandler[TP, None]]: ...
+) -> Callable[[PluginEventHandler[_TP, None]], PluginEventHandler[_TP, None]]: ...
 
 
 @overload
 def once(
     event_type: event_types.BUILTIN_EVENTS,
-) -> Callable[[PluginEventHandler[TP, context.TSCtx]], PluginEventHandler[TP, context.TSCtx]]: ...
+) -> Callable[[PluginEventHandler[_TP, context.TSCtx]], PluginEventHandler[_TP, context.TSCtx]]: ...
 
 
 @overload
 def once(
     event_type: event_types.BUILTIN_NO_CTX_EVENTS,
-) -> Callable[[PluginEventHandler[TP, None]], PluginEventHandler[TP, None]]: ...
+) -> Callable[[PluginEventHandler[_TP, None]], PluginEventHandler[_TP, None]]: ...
 
 
 @overload
 def once(
     event_type: event_types.TS_EVENTS,
-) -> Callable[[PluginEventHandler[TP, context.TSCtx]], PluginEventHandler[TP, context.TSCtx]]: ...
+) -> Callable[[PluginEventHandler[_TP, context.TSCtx]], PluginEventHandler[_TP, context.TSCtx]]: ...
 
 
 @overload
 def once(
     event_type: str,
-) -> Callable[[PluginEventHandler[TP, Any]], PluginEventHandler[TP, Any]]: ...
+) -> Callable[[PluginEventHandler[_TP, Any]], PluginEventHandler[_TP, Any]]: ...
 
 
 def once(
     event_type: str,
-) -> Callable[[PluginEventHandler[TP, Any]], PluginEventHandler[TP, Any]]:
+) -> Callable[[PluginEventHandler[_TP, Any]], PluginEventHandler[_TP, Any]]:
     """Decorator to register plugin events to be ran only once"""
 
     utils.check_for_deprecated_event(event_type)
 
-    def once_decorator(func: PluginEventHandler[TP, Any]) -> PluginEventHandler[TP, Any]:
+    def once_decorator(func: PluginEventHandler[_TP, Any]) -> PluginEventHandler[_TP, Any]:
         setattr(func, ONCE_ATTR, EventKwargs(event_type=event_type))
         return func
 

--- a/tsbot/tasks/manager.py
+++ b/tsbot/tasks/manager.py
@@ -49,7 +49,7 @@ class TaskManager:
         return not self._task_list
 
     def _start_task(self, bot: bot.TSBot, task: tasks.TSTask) -> None:
-        task.task = asyncio.create_task(task.handler(bot), name=task.name)
+        task.task = asyncio.create_task(task.handler(bot, *task.args), name=task.name)
         self._task_list.add(task.task)
         task.task.add_done_callback(self._task_callback)
         logger.debug("Started a task handler %r", getattr(task.handler, "__name__", task.handler))

--- a/tsbot/tasks/manager.py
+++ b/tsbot/tasks/manager.py
@@ -22,6 +22,9 @@ class TaskList:
     def __iter__(self) -> Generator[asyncio.Task[None], None, None]:
         yield from self.tasks
 
+    def __bool__(self) -> bool:
+        return bool(self.tasks)
+
     def add(self, task: asyncio.Task[None]) -> None:
         self._empty.clear()
         self.tasks.add(task)
@@ -43,7 +46,7 @@ class TaskManager:
 
     @property
     def empty(self) -> bool:
-        return not bool(self._task_list.tasks)
+        return not self._task_list
 
     def _start_task(self, bot: bot.TSBot, task: tasks.TSTask) -> None:
         task.task = asyncio.create_task(task.handler(bot), name=task.name)

--- a/tsbot/tasks/task.py
+++ b/tsbot/tasks/task.py
@@ -21,7 +21,7 @@ class TaskHandler(Protocol[Unpack[_Ts]]):
 @dataclass(slots=True)
 class TSTask:
     handler: TaskHandler[Unpack[tuple[Any, ...]]]
-    args: tuple[Any, ...]
+    args: tuple[Any, ...] = ()
     name: str | None = None
     task: asyncio.Task[None] | None = None
 

--- a/tsbot/tasks/task.py
+++ b/tsbot/tasks/task.py
@@ -2,29 +2,35 @@ from __future__ import annotations
 
 import asyncio
 import functools
-from collections.abc import Callable, Coroutine
+from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol
+
+from typing_extensions import TypeVarTuple, Unpack
 
 if TYPE_CHECKING:
     from tsbot import bot
 
+_Ts = TypeVarTuple("_Ts")
 
-TaskHandler = Callable[["bot.TSBot"], Coroutine[None, None, None]]
+
+class TaskHandler(Protocol[Unpack[_Ts]]):
+    def __call__(self, bot: bot.TSBot, *args: Unpack[_Ts]) -> Coroutine[None, None, None]: ...
 
 
 @dataclass(slots=True)
 class TSTask:
-    handler: TaskHandler
+    handler: TaskHandler[Unpack[tuple[Any, ...]]]
+    args: tuple[Any, ...]
     name: str | None = None
     task: asyncio.Task[None] | None = None
 
 
-def every(every_handler: TaskHandler, seconds: float) -> TaskHandler:
+def every(every_handler: TaskHandler[Unpack[_Ts]], seconds: float) -> TaskHandler[Unpack[_Ts]]:
     @functools.wraps(every_handler)
-    async def every_wrapper(bot: bot.TSBot) -> None:
+    async def every_wrapper(bot: bot.TSBot, *args: Unpack[_Ts]) -> None:
         while True:
             await asyncio.sleep(seconds)
-            await every_handler(bot)
+            await every_handler(bot, *args)
 
     return every_wrapper


### PR DESCRIPTION
Task handlers are strictly defined. The only argument has to be the bot instance.
If you wanted to pass more arguments to the task, you had to use `functools.partial` to achieve such.

This PR adds ability to pass arguments straight to the task.

```python
async def background_task(bot: TSBot, arg1: str, arg2: int) -> None:
    print(arg1, arg2)
    # ...

bot.register_task(background_task, "test", 1, name="TestTask")
```

Only positional arguments are supported.