### PR TITLE
Debug query timing

### DIFF
--- a/tsbot/connection/reader.py
+++ b/tsbot/connection/reader.py
@@ -98,7 +98,7 @@ class Reader:
     async def _task(self) -> None:
         async def read_gen() -> AsyncGenerator[str, None]:
             while await self._ready_to_read.wait() and (data := await self._connection.readline()):
-                logger.debug("Got data: %r", data)
+                logger.debug("Received data: %r", data)
                 yield data.rstrip()
 
         async with contextlib.aclosing(read_gen()) as g:

--- a/tsbot/connection/writer.py
+++ b/tsbot/connection/writer.py
@@ -4,10 +4,13 @@ import asyncio
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from tsbot import context, events
+from tsbot import context, events, logging
 
 if TYPE_CHECKING:
     from tsbot import connection, ratelimiter
+
+
+logger = logging.get_logger(__name__)
 
 
 class Writer:
@@ -31,5 +34,6 @@ class Writer:
         if self._ratelimiter:
             await self._ratelimiter.wait()
 
+        logger.debug("Sending data: %r", raw_query)
         await self._connection.write(raw_query)
         self._on_send(events.TSEvent("send", context.TSCtx({"query": raw_query})))

--- a/tsbot/logging.py
+++ b/tsbot/logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import MutableMapping
+from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 # TODO: Python 3.10 compat. Remove when 3.10 EOL
@@ -9,6 +10,9 @@ if TYPE_CHECKING:
     _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
 else:
     _LoggerAdapter = logging.LoggerAdapter
+
+
+__all__ = ("CRITICAL", "DEBUG", "ERROR", "INFO", "WARNING", "get_logger", "set_debug")
 
 
 _logger = logging.getLogger(__package__ or "tsbot")

--- a/tsbot/utils.py
+++ b/tsbot/utils.py
@@ -5,13 +5,6 @@ import logging
 import time
 import warnings
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
-
-# TODO: Python 3.10 compat. Remove when 3.10 EOL
-if TYPE_CHECKING:
-    _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
-else:
-    _LoggerAdapter = logging.LoggerAdapter
 
 
 def check_for_deprecated_event(event_type: str) -> None:
@@ -25,7 +18,7 @@ def check_for_deprecated_event(event_type: str) -> None:
 
 @contextlib.asynccontextmanager
 async def time_coroutine(
-    logger: _LoggerAdapter, level: int, message: str
+    logger: logging.LoggerAdapter[logging.Logger], level: int, message: str
 ) -> AsyncGenerator[None, None]:
     if logger.isEnabledFor(level):
         start = time.monotonic()

--- a/tsbot/utils.py
+++ b/tsbot/utils.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
 
+import contextlib
+import logging
+import time
 import warnings
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+# TODO: Python 3.10 compat. Remove when 3.10 EOL
+if TYPE_CHECKING:
+    _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
+else:
+    _LoggerAdapter = logging.LoggerAdapter
 
 
 def check_for_deprecated_event(event_type: str) -> None:
@@ -10,3 +21,17 @@ def check_for_deprecated_event(event_type: str) -> None:
             DeprecationWarning,
             stacklevel=3,
         )
+
+
+@contextlib.asynccontextmanager
+async def time_coroutine(
+    logger: _LoggerAdapter, level: int, message: str
+) -> AsyncGenerator[None, None]:
+    if logger.isEnabledFor(level):
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            logger.log(level, message, time.monotonic() - start)
+    else:
+        yield


### PR DESCRIPTION
Adds a util to measure how long each query takes.

Logging level needs to be set to `logging.DEBUG` to log this information.

Example log line:
```
[DEBUG][20:07:13][tsbot][connection.connection] Query took 0.01268 seconds to execute
```