### PR TITLE
Batched queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,17 @@
-# Windows
-Thumbs.db
+# Editors
+.vscode/
+.idea/
+
+# Vagrant
+.vagrant/
 
 # Mac/OSX
 .DS_Store
 
+# Windows
+Thumbs.db
+
+# Source for the following rules: https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -26,7 +34,6 @@ parts/
 sdist/
 var/
 wheels/
-share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -52,10 +59,8 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
 .hypothesis/
 .pytest_cache/
-cover/
 
 # Translations
 *.mo
@@ -65,7 +70,6 @@ cover/
 *.log
 local_settings.py
 db.sqlite3
-db.sqlite3-journal
 
 # Flask stuff:
 instance/
@@ -78,7 +82,6 @@ instance/
 docs/_build/
 
 # PyBuilder
-.pybuilder/
 target/
 
 # Jupyter Notebook
@@ -89,46 +92,10 @@ profile_default/
 ipython_config.py
 
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
-.pdm-python
-.pdm-build/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
+# celery beat schedule file
 celerybeat-schedule
-celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
@@ -141,6 +108,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venvs/*
 
 # Spyder project settings
 .spyderproject
@@ -160,24 +128,5 @@ dmypy.json
 # ruff
 .ruff_cache
 
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-.idea/
-
-# VSCode
-.vscode/
-
-# Dev playground
+todo.md
 playground.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,9 @@
-# Editors
-.vscode/
-.idea/
-
-# Vagrant
-.vagrant/
+# Windows
+Thumbs.db
 
 # Mac/OSX
 .DS_Store
 
-# Windows
-Thumbs.db
-
-# Source for the following rules: https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -34,6 +26,7 @@ parts/
 sdist/
 var/
 wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -59,8 +52,10 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+*.py,cover
 .hypothesis/
 .pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -70,6 +65,7 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
+db.sqlite3-journal
 
 # Flask stuff:
 instance/
@@ -82,6 +78,7 @@ instance/
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
 
 # Jupyter Notebook
@@ -92,10 +89,46 @@ profile_default/
 ipython_config.py
 
 # pyenv
-.python-version
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
 
-# celery beat schedule file
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
 celerybeat-schedule
+celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
@@ -108,7 +141,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-venvs/*
 
 # Spyder project settings
 .spyderproject
@@ -128,5 +160,24 @@ dmypy.json
 # ruff
 .ruff_cache
 
-todo.md
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# VSCode
+.vscode/
+
+# Dev playground
 playground.py

--- a/docs/source/queries.md
+++ b/docs/source/queries.md
@@ -53,6 +53,7 @@ you can use the [bot.send_batched()](tsbot.bot.TSBot.send_batched) method.
 Some query commands allow you to target multiple actions at once.
 For example `clientmove` allows you to move multiple clients at once.
 You should always prefer this over sending multiple move queries.
+Refer to the *TeamSpeak 3 ServerQuery Manual* if a command supports this behavior.
 
 ```python
 from tsbot import query
@@ -66,7 +67,7 @@ clientmove_query = (
 await bot.send(clientmove_query)
 ```
 
-If a query command doesn't support this, you can send multiple queries to achieve the same result.
+If a query command doesn't support multiple actions, you can send multiple queries to achieve the same result.
 For example `clientpoke` only allows you to target one client at a time.
 ````
 

--- a/docs/source/queries.md
+++ b/docs/source/queries.md
@@ -7,8 +7,7 @@ myst:
 
 # Queries
 
-TSBot implements a query builder to ease the use of building commands.  
-In this chapter you will learn how to use the query system.
+TSBot implements a query builder to ease the use of building commands.
 
 ---
 
@@ -30,19 +29,72 @@ This creates {{TSQuery}} object which you can manipulate to build out your comma
 ## Sending queries
 
 Sending queries to the server is as simple as awaiting calls to [bot.send()](tsbot.bot.TSBot.send) method.  
-The [bot.send()](tsbot.bot.TSBot.send) method takes {{TSQuery}} objects as its first argument.
+The [bot.send()](tsbot.bot.TSBot.send) method takes {{TSQuery}} objects as its only argument.
 
 ```python
 from tsbot import query
 
 clientlist_query = query("clientlist").option("uid")
-bot.send(clientlist_query)
+await bot.send(clientlist_query)
 ```
 
-To send raw commands to the server, use [bot.send_raw()](tsbot.bot.TSBot.send_raw) method.
+To send raw queries to the server, use [bot.send_raw()](tsbot.bot.TSBot.send_raw) method.
 
 ```python
-bot.send_raw("clientlist -uid")
+await bot.send_raw("clientlist -uid")
+```
+
+## Sending multiple queries
+
+If you have multiple queries and those queries only cause side effects on the server without returning any data,
+you can use the [bot.send_batched()](tsbot.bot.TSBot.send_batched) method.
+
+````{note}
+Some query commands allow you to target multiple actions at once.
+For example `clientmove` allows you to move multiple clients at once.
+You should always prefer this over sending multiple move queries.
+
+```python
+from tsbot import query
+
+clientmove_query = (
+    query("clientmove")
+    .params(cid=1)
+    .param_block({"clid": client_id} for client_id in (3, 4, 5))
+)
+
+await bot.send(clientmove_query)
+```
+
+If a query command doesn't support this, you can send multiple queries to achieve the same result.
+For example `clientpoke` only allows you to target one client at a time.
+````
+
+The [bot.send_batched()](tsbot.bot.TSBot.send_batched) method takes an iterable of {{TSQuery}} objects as its only argument.
+
+```python
+from tsbot import query
+
+clientpoke_query = query("clientpoke").params(msg="Wake up!")
+await bot.send_batched(
+    (
+        clientpoke_query.params(clid=1),
+        clientpoke_query.params(clid=2),
+        clientpoke_query.params(clid=3),
+    )
+)
+```
+
+Alternatively, you can send multiple raw queries using the [bot.send_batched_raw()](tsbot.bot.TSBot.send_batched_raw) method.
+
+```python
+await bot.send_batched_raw(
+    (
+        r"clientpoke clid=1 msg=Wake\sup!",
+        r"clientpoke clid=2 msg=Wake\sup!",
+        r"clientpoke clid=3 msg=Wake\sup!",
+    )
+)
 ```
 
 ---
@@ -56,7 +108,7 @@ This allows you to [method cascade](https://en.wikipedia.org/wiki/Method_cascadi
 
 ### Adding options
 
-You can add options to your commands by using [option()](<tsbot.query_builder.TSQuery.option()>) method.  
+You can add options to your commands by using [option()](<tsbot.query_builder.TSQuery.option()>) method.
 The method [option()](<tsbot.query_builder.TSQuery.option()>) accepts as **_many arguments_** as you provide it or you can add them **_one by one_**.
 
 ```python

--- a/examples/batched_queries.py
+++ b/examples/batched_queries.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+
+from tsbot import TSBot, TSCtx, query
+
+"""
+Example to send multiple queries to the server at once
+
+Some queries have no real reason to wait for a response from the server.
+Sending a bunch of these queries can cause massive slowdowns.
+Each query has to be sent one-by-one due to limitations of the Server Query interface.
+This means each query has to wait for a response from the server before another query can be sent.
+
+In cases of high latency and/or high amount of queries, you can use `bot.send_batched()` methods.
+These methods allow you to send multiple queries at once, while discarding the responses.
+"""
+
+
+bot = TSBot(
+    username="USERNAME",
+    password="PASSWORD",
+    address="ADDRESS",
+)
+
+
+@bot.command("poke", help_text="pokes all clients with a message")
+async def poke_all_clients(bot: TSBot, ctx: TSCtx, message: str) -> None:
+    clients_list = await bot.send(query("clientlist"))
+    poke_query = query("clientpoke").params(msg=message)
+
+    await bot.send_batched(
+        poke_query.params(clid=client["clid"])
+        for client in clients_list
+        if client["client_type"] == "0"
+    )
+
+
+asyncio.run(bot.run())

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import inspect
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar, cast, overload
 
 from typing_extensions import TypeVarTuple, Unpack, deprecated
@@ -528,6 +528,16 @@ class TSBot:
         :return: Response from the server.
         """
         return await self._connection.send_raw(raw_query)
+
+    async def send_batched(self, queries: Iterable[query_builder.TSQuery]) -> None:
+        # TODO: Docstring
+
+        await self._connection.send_batched(queries)
+
+    async def send_batched_raw(self, raw_queries: Iterable[str]) -> None:
+        # TODO: Docstring
+
+        await self._connection.send_batched_raw(raw_queries)
 
     def close(self) -> None:
         """

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -530,12 +530,20 @@ class TSBot:
         return await self._connection.send_raw(raw_query)
 
     async def send_batched(self, queries: Iterable[query_builder.TSQuery]) -> None:
-        # TODO: Docstring
+        """
+        Sends multiple queries to the server, ignoring the response.
+
+        :param queries: Iterable of :class:`TSQuery<tsbot.query_builder.TSQuery>` instances to be send to the server.
+        """
 
         await self._connection.send_batched(queries)
 
     async def send_batched_raw(self, raw_queries: Iterable[str]) -> None:
-        # TODO: Docstring
+        """
+        Sends multiple raw commands to the server, ignoring the response.
+
+        :param queries: Iterable of raw query commands to be send to the server.
+        """
 
         await self._connection.send_batched_raw(raw_queries)
 

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
-from collections.abc import Coroutine
+from collections.abc import Collection, Coroutine
 from typing import TYPE_CHECKING, Any
 
 from tsbot import exceptions, logging, query_builder, response, utils
@@ -196,3 +196,18 @@ class TSConnection:
         await self._writer.write(raw_query)
         return response.TSResponse.from_server_response(await self._reader.read_response())
 
+    async def send_batched(self, queries: Collection[query_builder.TSQuery]) -> None:
+        await self.send_batched_raw(tuple(query.compile() for query in queries))
+
+    async def send_batched_raw(self, queries: Collection[str]) -> None:
+        async with self._sending_lock:
+            await self._send_batched(queries)
+
+    @utils.time_coroutine(logger, logging.DEBUG, "Batch query took %.5f seconds to execute")
+    async def _send_batched(self, queries: Collection[str]) -> None:
+        if self._closed:
+            raise BrokenPipeError("Connection to the TeamSpeak server is closed")
+
+        await self._connection.write(self._connection.LINE_ENDING.join(queries))
+        for _ in range(len(queries)):
+            await self._reader.read_response()

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -197,7 +197,7 @@ class TSConnection:
         return response.TSResponse.from_server_response(await self._reader.read_response())
 
     async def send_batched(self, queries: Iterable[query_builder.TSQuery]) -> None:
-        await self.send_batched_raw(tuple(query.compile() for query in queries))
+        await self.send_batched_raw(query.compile() for query in queries)
 
     async def send_batched_raw(self, queries: Iterable[str]) -> None:
         async with self._sending_lock:

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -208,16 +208,17 @@ class TSConnection:
         if self._closed:
             raise BrokenPipeError("Connection to the TeamSpeak server is closed")
 
-        count = 0
+        queries_sent = 0
 
         try:
-            for count, raw_query in enumerate(queries):
+            for raw_query in queries:
                 # This is still slow, because `.write()` flushes on each call.
                 # If the connection is ratelimited, this behavior is wanted.
                 # If not ratelimited, should flush only after the last query.
                 # TODO: Optimize non-ratelimited case
                 await self._writer.write(raw_query)
+                queries_sent += 1
 
         finally:
-            for _ in range(count):
+            for _ in range(queries_sent):
                 await self._reader.read_response()

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import itertools
-
-from collections.abc import Callable, Coroutine, Iterable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 from tsbot import context, events, exceptions, logging, query_builder, response, utils

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -212,13 +212,8 @@ class TSConnection:
 
         try:
             for raw_query in queries:
-                # This is still slow, because `.write()` flushes on each call.
-                # If the connection is ratelimited, this behavior is wanted.
-                # If not ratelimited, should flush only after the last query.
-                # TODO: Optimize non-ratelimited case
                 await self._writer.write(raw_query)
                 queries_sent += 1
 
         finally:
-            for _ in range(queries_sent):
-                await self._reader.read_response()
+            self._reader.skip_response(queries_sent)

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -208,6 +208,12 @@ class TSConnection:
         if self._closed:
             raise BrokenPipeError("Connection to the TeamSpeak server is closed")
 
-        await self._connection.write(self._connection.LINE_ENDING.join(queries))
-        for _ in range(len(queries)):
-            await self._reader.read_response()
+        count = 0
+
+        try:
+            for count, raw_query in enumerate(queries):
+                await self._writer.write(raw_query)
+
+        finally:
+            for _ in range(count):
+                await self._reader.read_response()

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -212,6 +212,10 @@ class TSConnection:
 
         try:
             for count, raw_query in enumerate(queries):
+                # This is still slow, because `.write()` flushes on each call.
+                # If the connection is ratelimited, this behavior is wanted.
+                # If not ratelimited, should flush only after the last query.
+                # TODO: Optimize non-ratelimited case
                 await self._writer.write(raw_query)
 
         finally:

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -5,11 +5,11 @@ import itertools
 from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any
 
-from tsbot import exceptions, logging, query_builder, utils
+from tsbot import exceptions, logging, query_builder, response, utils
 from tsbot.connection import reader, writer
 
 if TYPE_CHECKING:
-    from tsbot import bot, connection, events, ratelimiter, response
+    from tsbot import bot, connection, events, ratelimiter
 
 
 logger = logging.get_logger(__name__)
@@ -194,4 +194,5 @@ class TSConnection:
             raise BrokenPipeError("Connection to the TeamSpeak server is closed")
 
         await self._writer.write(raw_query)
-        return await self._reader.read_response()
+        return response.TSResponse.from_server_response(await self._reader.read_response())
+

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
-from collections.abc import Collection, Coroutine
+from collections.abc import Coroutine, Iterable
 from typing import TYPE_CHECKING, Any
 
 from tsbot import exceptions, logging, query_builder, response, utils
@@ -196,15 +196,15 @@ class TSConnection:
         await self._writer.write(raw_query)
         return response.TSResponse.from_server_response(await self._reader.read_response())
 
-    async def send_batched(self, queries: Collection[query_builder.TSQuery]) -> None:
+    async def send_batched(self, queries: Iterable[query_builder.TSQuery]) -> None:
         await self.send_batched_raw(tuple(query.compile() for query in queries))
 
-    async def send_batched_raw(self, queries: Collection[str]) -> None:
+    async def send_batched_raw(self, queries: Iterable[str]) -> None:
         async with self._sending_lock:
             await self._send_batched(queries)
 
     @utils.time_coroutine(logger, logging.DEBUG, "Batch query took %.5f seconds to execute")
-    async def _send_batched(self, queries: Collection[str]) -> None:
+    async def _send_batched(self, queries: Iterable[str]) -> None:
         if self._closed:
             raise BrokenPipeError("Connection to the TeamSpeak server is closed")
 

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -194,24 +194,25 @@ class TSConnection:
             raise BrokenPipeError("Connection to the TeamSpeak server is closed")
 
         await self._writer.write(raw_query)
-        return response.TSResponse.from_server_response(await self._reader.read_response())
+        response_data = await self._reader.read_response()
+        return response.TSResponse.from_server_response(response_data)
 
     async def send_batched(self, queries: Iterable[query_builder.TSQuery]) -> None:
         await self.send_batched_raw(query.compile() for query in queries)
 
-    async def send_batched_raw(self, queries: Iterable[str]) -> None:
+    async def send_batched_raw(self, raw_queries: Iterable[str]) -> None:
         async with self._sending_lock:
-            await self._send_batched(queries)
+            await self._send_batched(raw_queries)
 
     @utils.time_coroutine(logger, logging.DEBUG, "Batch query took %.5f seconds to execute")
-    async def _send_batched(self, queries: Iterable[str]) -> None:
+    async def _send_batched(self, raw_queries: Iterable[str]) -> None:
         if self._closed:
             raise BrokenPipeError("Connection to the TeamSpeak server is closed")
 
         queries_sent = 0
 
         try:
-            for raw_query in queries:
+            for raw_query in raw_queries:
                 await self._writer.write(raw_query)
                 queries_sent += 1
 

--- a/tsbot/connection/connection_types/abc.py
+++ b/tsbot/connection/connection_types/abc.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 
 
 class Connection(ABC):
+    LINE_ENDING: str = "\n\r"
+
     @abstractmethod
     async def connect(self) -> None:
         """

--- a/tsbot/connection/connection_types/raw_connection.py
+++ b/tsbot/connection/connection_types/raw_connection.py
@@ -65,7 +65,7 @@ class RawConnection(abc.Connection):
         if not self._writer or self._writer.is_closing():
             raise BrokenPipeError("Trying to write on a closed connection")
 
-        self._writer.write(f"{data}\n\r".encode())
+        self._writer.write(f"{data}{self.LINE_ENDING}".encode())
         await self._writer.drain()
 
     @override
@@ -74,6 +74,6 @@ class RawConnection(abc.Connection):
             raise ConnectionResetError("Reading on a closed connection")
 
         try:
-            return (await self._reader.readuntil(b"\n\r")).decode()
+            return (await self._reader.readuntil(self.LINE_ENDING.encode())).decode()
         except Exception:
             return None

--- a/tsbot/connection/connection_types/ssh_connection.py
+++ b/tsbot/connection/connection_types/ssh_connection.py
@@ -42,6 +42,7 @@ class SSHConnection(abc.Connection):
             raise ConnectionAbortedError("Invalid TeamSpeak server")
         await self.readline()
 
+    @override
     async def authenticate(self) -> None:
         """Teamspeak SSH query clients are already authenticated on connect"""
 

--- a/tsbot/connection/connection_types/ssh_connection.py
+++ b/tsbot/connection/connection_types/ssh_connection.py
@@ -67,7 +67,7 @@ class SSHConnection(abc.Connection):
         if not self._writer or self._writer.is_closing():
             raise BrokenPipeError("Trying to write on a closed connection")
 
-        self._writer.write(f"{data}\n\r")
+        self._writer.write(f"{data}{self.LINE_ENDING}")
         await self._writer.drain()
 
     @override
@@ -76,6 +76,6 @@ class SSHConnection(abc.Connection):
             raise ConnectionResetError("Reading on a closed connection")
 
         try:
-            return await self._reader.readuntil("\n\r")
+            return await self._reader.readuntil(self.LINE_ENDING)
         except Exception:
             return None

--- a/tsbot/connection/reader.py
+++ b/tsbot/connection/reader.py
@@ -6,7 +6,7 @@ import contextlib
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any
 
-from tsbot import events, logging, response
+from tsbot import events, logging
 
 if TYPE_CHECKING:
     from tsbot import connection
@@ -120,7 +120,5 @@ class Reader:
         async with contextlib.aclosing(self._pop_till_error_line()) as g:
             return tuple([line async for line in g])
 
-    async def read_response(self) -> response.TSResponse:
-        return response.TSResponse.from_server_response(
-            await asyncio.wait_for(self._get_response(), timeout=self._read_timeout)
-        )
+    async def read_response(self) -> tuple[str, ...]:
+        return await asyncio.wait_for(self._get_response(), timeout=self._read_timeout)

--- a/tsbot/connection/reader.py
+++ b/tsbot/connection/reader.py
@@ -86,6 +86,9 @@ class Reader:
     def __exit__(self, *exc: Any) -> None:
         self.close()
 
+    def skip_response(self, count: int = 1) -> None:
+        self._skipped_responses += count
+
     def start(self) -> None:
         self._reader_task = asyncio.create_task(self._task(), name="Reader-Task")
 
@@ -134,6 +137,3 @@ class Reader:
             raise
 
         return response
-
-    def skip_response(self, count: int = 1) -> None:
-        self._skipped_responses += count

--- a/tsbot/connection/reader.py
+++ b/tsbot/connection/reader.py
@@ -112,7 +112,7 @@ class Reader:
                 logger.debug("Received data: %r", data)
                 yield data.rstrip()
 
-        read_buffer: collections.deque[str] = collections.deque()
+        read_buffer: list[str] = []
 
         async with contextlib.aclosing(read_gen()) as g:
             async for data in g:

--- a/tsbot/connection/reader.py
+++ b/tsbot/connection/reader.py
@@ -130,9 +130,9 @@ class Reader:
         return await self._response_buffer.pop()
 
     async def read_response(self) -> tuple[str, ...]:
-        while self._skipped_responses > 0:
-            await self._get_response()
-            self._skipped_responses -= 1
+        if self._skipped_responses > 0:
+            await self._response_buffer.discard(self._skipped_responses)
+            self._skipped_responses = 0
 
         try:
             response = await asyncio.wait_for(self._get_response(), timeout=self._read_timeout)
@@ -141,4 +141,3 @@ class Reader:
             raise
 
         return response
-

--- a/tsbot/connection/reader.py
+++ b/tsbot/connection/reader.py
@@ -15,9 +15,9 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class _ReadBuffer:
+class _ResponseBuffer:
     def __init__(self) -> None:
-        self._deque: collections.deque[str] = collections.deque()
+        self._deque: collections.deque[tuple[str, ...]] = collections.deque()
         self._getters: collections.deque[asyncio.Future[None]] = collections.deque()
 
     def _wakeup_getters(self) -> None:
@@ -27,15 +27,21 @@ class _ReadBuffer:
                 getter.set_result(None)
                 break
 
-    @property
-    def empty(self) -> bool:
-        return not self._deque
+    def __len__(self) -> int:
+        return len(self._deque)
+
+    def __bool__(self) -> bool:
+        return bool(self._deque)
 
     def clear(self) -> None:
         self._deque.clear()
 
+    async def discard(self, count: int = 1) -> None:
+        for _ in range(count):
+            await self.pop()
+
     async def _wakeup_on_available_item(self) -> None:
-        while self.empty:
+        while not self:
             getter = asyncio.get_running_loop().create_future()
             self._getters.append(getter)
 
@@ -48,16 +54,16 @@ class _ReadBuffer:
                 with contextlib.suppress(ValueError):
                     self._getters.remove(getter)
 
-                if not self.empty and not getter.cancelled():
+                if self and not getter.cancelled():
                     self._wakeup_getters()
 
                 raise
 
-    async def pop(self) -> str:
+    async def pop(self) -> tuple[str, ...]:
         await self._wakeup_on_available_item()
         return self._deque.popleft()
 
-    def put(self, item: str) -> None:
+    def put(self, item: tuple[str, ...]) -> None:
         self._deque.append(item)
         self._wakeup_getters()
 
@@ -77,7 +83,7 @@ class Reader:
 
         self._skipped_responses = 0
 
-        self._read_buffer = _ReadBuffer()
+        self._response_buffer = _ResponseBuffer()
         self._reader_task: asyncio.Task[None] | None = None
 
     def __enter__(self) -> None:
@@ -93,7 +99,7 @@ class Reader:
         self._reader_task = asyncio.create_task(self._task(), name="Reader-Task")
 
     def close(self) -> None:
-        self._read_buffer.clear()
+        self._response_buffer.clear()
 
         if self._reader_task:
             self._reader_task.cancel()
@@ -106,24 +112,22 @@ class Reader:
                 logger.debug("Received data: %r", data)
                 yield data.rstrip()
 
+        read_buffer: collections.deque[str] = collections.deque()
+
         async with contextlib.aclosing(read_gen()) as g:
             async for data in g:
                 if data.startswith("notify"):
                     self._on_notify(data)
-                else:
-                    self._read_buffer.put(data)
+                    continue
 
-    async def _pop_till_error_line(self) -> AsyncGenerator[str, None]:
-        data = await self._read_buffer.pop()
-        yield data
+                read_buffer.append(data)
 
-        while not data.startswith("error"):
-            data = await self._read_buffer.pop()
-            yield data
+                if data.startswith("error"):
+                    self._response_buffer.put(tuple(read_buffer))
+                    read_buffer.clear()
 
     async def _get_response(self) -> tuple[str, ...]:
-        async with contextlib.aclosing(self._pop_till_error_line()) as g:
-            return tuple([line async for line in g])
+        return await self._response_buffer.pop()
 
     async def read_response(self) -> tuple[str, ...]:
         while self._skipped_responses > 0:


### PR DESCRIPTION
Add ability to send multiple queries without a response.

Some queries only cause side effects on the server and return nothing important.
When sending bunch of these queries, this can cause unnecessary slowdowns due to waiting on responses.

Example:
```python
@bot.command("poke", help_text="pokes all clients with a message")
async def poke(bot: TSBot, ctx: TSCtx, message: str) -> None:
    clients_list = await bot.send(query("clientlist"))
    poke_query = query("clientpoke").params(msg=message)

    await bot.send_batched(
        poke_query.params(clid=client["clid"])
        for client in clients_list
        if client["client_type"] == "0"
    )
```

Responses are skipped on next read.