### PR TITLE
Remove `ready` event

### DIFF
--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -6,7 +6,7 @@ import inspect
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar, cast, overload
 
-from typing_extensions import TypeVarTuple, Unpack, deprecated
+from typing_extensions import TypeVarTuple, Unpack
 
 from tsbot import (
     commands,
@@ -20,7 +20,6 @@ from tsbot import (
     ratelimiter,
     response,
     tasks,
-    utils,
 )
 
 if TYPE_CHECKING:
@@ -156,12 +155,6 @@ class TSBot:
         self._event_manager.add_event(event)
 
     @overload
-    @deprecated("'ready' event is deprecated. Use 'connect' instead")
-    def on(
-        self, event_type: Literal["ready"]
-    ) -> Callable[[EventHandler[None]], EventHandler[None]]: ...
-
-    @overload
     def on(
         self, event_type: event_types.BUILTIN_EVENTS
     ) -> Callable[[EventHandler[context.TSCtx]], EventHandler[context.TSCtx]]: ...
@@ -186,19 +179,11 @@ class TSBot:
         :param event_type: Name of the event.
         """
 
-        utils.check_for_deprecated_event(event_type)
-
         def event_decorator(func: _TEH) -> _TEH:
             self.register_event_handler(event_type, func)
             return func
 
         return event_decorator
-
-    @overload
-    @deprecated("'ready' event is deprecated. Use 'connect' instead")
-    def register_event_handler(
-        self, event_type: Literal["ready"], handler: EventHandler[None]
-    ) -> events.TSEventHandler: ...
 
     @overload
     def register_event_handler(
@@ -231,17 +216,9 @@ class TSBot:
         :return: The instance of :class:`TSEventHandler<tsbot.events.TSEventHandler>` created.
         """
 
-        utils.check_for_deprecated_event(event_type)
-
         event_handler = events.TSEventHandler(event_type, handler)
         self._event_manager.register_event_handler(event_handler)
         return event_handler
-
-    @overload
-    @deprecated("'ready' event is deprecated. Use 'connect' instead")
-    def once(
-        self, event_type: Literal["ready"]
-    ) -> Callable[[EventHandler[None]], EventHandler[None]]: ...
 
     @overload
     def once(
@@ -268,19 +245,11 @@ class TSBot:
         :param event_type: Name of the event.
         """
 
-        utils.check_for_deprecated_event(event_type)
-
         def once_decorator(func: _TEH) -> _TEH:
             self.register_once_handler(event_type, func)
             return func
 
         return once_decorator
-
-    @overload
-    @deprecated("'ready' event is deprecated. Use 'connect' instead")
-    def register_once_handler(
-        self, event_type: Literal["ready"], handler: EventHandler[None]
-    ) -> events.TSEventOnceHandler: ...
 
     @overload
     def register_once_handler(
@@ -312,8 +281,6 @@ class TSBot:
         :param handler: Async function to handle the event.
         :return: The instance of :class:`TSEventOnceHandler<tsbot.events.TSEventOnceHandler>` created.
         """
-
-        utils.check_for_deprecated_event(event_type)
 
         event_handler = events.TSEventOnceHandler(event_type, handler, self.remove_event_handler)
         self._event_manager.register_event_handler(event_handler)

--- a/tsbot/connection/connection.py
+++ b/tsbot/connection/connection.py
@@ -161,8 +161,6 @@ class TSConnection:
                 self._is_first_connection = False
 
                 self._event_emitter(events.TSEvent("connect"))
-                # TODO: deprecated, remove when appropriate
-                self._event_emitter(events.TSEvent("ready"))
 
                 with contextlib.suppress(ConnectionError):
                     await self._connection.wait_closed()

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine, Sequence
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar, overload
 
-from typing_extensions import deprecated
-
-from tsbot import utils
-
 if TYPE_CHECKING:
     from tsbot import bot, context
     from tsbot.commands import CommandHandler
@@ -96,13 +92,6 @@ def command(
 
 
 @overload
-@deprecated("'ready' event is deprecated. Use 'connect' instead")
-def on(
-    event_type: Literal["ready"],
-) -> Callable[[PluginEventHandler[_TP, None]], PluginEventHandler[_TP, None]]: ...
-
-
-@overload
 def on(
     event_type: event_types.BUILTIN_EVENTS,
 ) -> Callable[[PluginEventHandler[_TP, context.TSCtx]], PluginEventHandler[_TP, context.TSCtx]]: ...
@@ -131,20 +120,11 @@ def on(
 ) -> Callable[[_TH], _TH]:
     """Decorator to register plugin events"""
 
-    utils.check_for_deprecated_event(event_type)
-
     def event_decorator(func: _TH) -> _TH:
         setattr(func, EVENT_ATTR, EventKwargs(event_type=event_type))
         return func
 
     return event_decorator
-
-
-@overload
-@deprecated("'ready' event is deprecated. Use 'connect' instead")
-def once(
-    event_type: Literal["ready"],
-) -> Callable[[PluginEventHandler[_TP, None]], PluginEventHandler[_TP, None]]: ...
 
 
 @overload
@@ -175,8 +155,6 @@ def once(
     event_type: str,
 ) -> Callable[[_TH], _TH]:
     """Decorator to register plugin events to be ran only once"""
-
-    utils.check_for_deprecated_event(event_type)
 
     def once_decorator(func: _TH) -> _TH:
         setattr(func, ONCE_ATTR, EventKwargs(event_type=event_type))

--- a/tsbot/utils.py
+++ b/tsbot/utils.py
@@ -4,17 +4,7 @@ import asyncio
 import contextlib
 import logging
 import time
-import warnings
 from collections.abc import AsyncGenerator, Generator
-
-
-def check_for_deprecated_event(event_type: str) -> None:
-    if event_type == "ready":
-        warnings.warn(
-            "'ready' event is deprecated. Use 'connect' instead",
-            DeprecationWarning,
-            stacklevel=3,
-        )
 
 
 @contextlib.asynccontextmanager


### PR DESCRIPTION
Fully deprecate/remove `ready` event.

### Migration guide:
Change `ready` event to `connect`.

```python
@bot.on("ready")  # Change "ready" -> "connect"
async def handler(bot: TSBot, ctx: None) -> None:
    # ...
```