### PR TITLE
Response getters

### DIFF
--- a/examples/command_checks_server_groups.py
+++ b/examples/command_checks_server_groups.py
@@ -22,7 +22,7 @@ async def check_server_groups(bot: TSBot, ctx: TSCtx, *args: str, **kwargs: str)
     """Check if client has allowed server group. If not, raise permission error"""
 
     ids = await bot.send(GET_DATABASE_ID_QUERY.params(cluid=ctx["invokeruid"]))
-    groups = await bot.send(SERVER_GROUPS_BY_ID_QUERY.params(cldbid=ids.first["cldbid"]))
+    groups = await bot.send(SERVER_GROUPS_BY_ID_QUERY.params(cldbid=ids["cldbid"]))
 
     # Switch 'g == sg["name"]' to 'g in sg["name"]' if you don't want to match strictly
     if not any(g == sg["name"] for g in ALLOWED_SERVER_GROUPS for sg in groups):

--- a/examples/file_transfer.py
+++ b/examples/file_transfer.py
@@ -67,11 +67,11 @@ async def upload(
 
     resp = await bot.send(init_query)
 
-    if resp.first.get("status") == "2050":
+    if resp.get("status") == "2050":
         raise TSException("File already exists")
 
-    ftkey = resp.first["ftkey"]
-    address = (resp.first.get("ip", "127.0.0.1"), int(resp.first["port"]))
+    ftkey = resp["ftkey"]
+    address = (resp.get("ip", "127.0.0.1"), int(resp["port"]))
 
     return await asyncio.to_thread(_upload, file, ftkey, address)
 
@@ -114,11 +114,11 @@ async def download(
 
     resp = await bot.send(init_query)
 
-    if resp.first.get("status") == "2051":
+    if resp.get("status") == "2051":
         raise TSException("File not found")
 
-    ftkey = resp.first["ftkey"]
-    address = (resp.first.get("ip", "127.0.0.1"), int(resp.first["port"]))
+    ftkey = resp["ftkey"]
+    address = (resp.get("ip", "127.0.0.1"), int(resp["port"]))
 
     return await asyncio.to_thread(_download, file, ftkey, address)
 

--- a/examples/manual_handlers.py
+++ b/examples/manual_handlers.py
@@ -13,7 +13,7 @@ async def print_name_on_enter(bot: TSBot, ctx: TSCtx):
     info_query = query("clientinfo").params(clid=ctx["clid"])
     resp = await bot.send(info_query)
 
-    print(f"{resp.first['client_nickname']} has entered the server")
+    print(f"{resp['client_nickname']} has entered the server")
 
 
 bot = TSBot(

--- a/examples/plugin_example.py
+++ b/examples/plugin_example.py
@@ -19,7 +19,7 @@ class TestPlugin(plugin.TSPlugin):
         info_query = query("clientinfo").params(clid=ctx["clid"])
         resp = await bot.send(info_query)
 
-        print(self.move_message.format(username=resp.first["client_nickname"]))
+        print(self.move_message.format(username=resp["client_nickname"]))
 
 
 bot = TSBot(

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -85,3 +85,21 @@ def test_response_iter():
 
     for index, client in enumerate(resp):
         assert client is resp.data[index]
+
+
+def test_response_getitem():
+    resp = response.TSResponse(
+        data=(
+            {"clid": "378", "cid": "23", "client_database_id": "21", "client_type": "0"},
+            {"clid": "377", "cid": "31", "client_database_id": "549", "client_type": "0"},
+            {"clid": "375", "cid": "31", "client_database_id": "46", "client_type": "0"},
+            {"clid": "371", "cid": "31", "client_database_id": "385", "client_type": "0"},
+            {"clid": "333", "cid": "45", "client_database_id": "27", "client_type": "0"},
+            {"clid": "3", "cid": "31", "client_database_id": "160", "client_type": "0"},
+        ),
+        error_id=0,
+        msg="ok",
+    )
+
+    for key in resp.data[0]:
+        assert resp[key] is resp.data[0][key]

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -43,24 +43,33 @@ def test_from_server_response(input_list: list[str], expected_values: dict[str, 
     assert resp.error_id == expected_values["error_id"]
 
 
-def test_first_property():
-    resp = response.TSResponse(
-        ({"version": "3.13.3", "build": "1608128225", "platform": "Windows"},), 0, "ok"
-    )
-    assert resp.first == {"version": "3.13.3", "build": "1608128225", "platform": "Windows"}
+@pytest.mark.parametrize(
+    ("resp",),
+    (
+        pytest.param(
+            response.TSResponse(
+                ({"version": "3.13.3", "build": "1608128225", "platform": "Windows"},), 0, "ok"
+            ),
+            id="test_one_datapoint",
+        ),
+        pytest.param(
+            response.TSResponse(({"ip": "0.0.0.0"}, {"ip": "::"}), 0, "ok"),
+            id="test_two_datapoint",
+        ),
+    ),
+)
+def test_first_property(resp: response.TSResponse):
+    assert resp.first == resp.data[0]
 
-    resp = response.TSResponse(({"ip": "0.0.0.0"}, {"ip": "::"}), 0, "ok")
-    assert resp.first == {"ip": "0.0.0.0"}
 
-
-def test_first_property_empty():
+def test_first_property_empty_raises():
     resp = response.TSResponse(tuple(), 0, "ok")
 
     with pytest.raises(IndexError):
         resp.first
 
 
-def test_iter_response():
+def test_response_iter():
     resp = response.TSResponse(
         data=(
             {"clid": "378", "cid": "23", "client_database_id": "21", "client_type": "0"},
@@ -74,5 +83,5 @@ def test_iter_response():
         msg="ok",
     )
 
-    for client in resp:
-        assert isinstance(client, dict)
+    for index, client in enumerate(resp):
+        assert client is resp.data[index]

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -541,7 +541,7 @@ class TSBot:
 
     async def _update_bot_info(self) -> None:
         """Update useful information about the bot instance"""
-        info = (await self.send_raw("whoami")).first
+        info = await self.send_raw("whoami")
 
         self._bot_info = BotInfo(
             uid=info["client_unique_identifier"],

--- a/tsbot/response.py
+++ b/tsbot/response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass
+from typing import overload
 
 from typing_extensions import Self
 
@@ -34,6 +35,16 @@ class TSResponse:
     def last(self) -> dict[str, str]:
         """Last datapoint from the response"""
         return self.data[-1]
+
+    @overload
+    def get(self, key: str, /) -> str | None: ...
+
+    @overload
+    def get(self, key: str, default: str, /) -> str: ...
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """Get the value of a key from the first datapoint"""
+        return self.first.get(key, default)
 
     @classmethod
     def from_server_response(cls, raw_data: Sequence[str]) -> Self:

--- a/tsbot/response.py
+++ b/tsbot/response.py
@@ -21,6 +21,10 @@ class TSResponse:
     def __iter__(self) -> Generator[dict[str, str], None, None]:
         yield from self.data
 
+    def __getitem__(self, key: str) -> str:
+        """Get the value of a key from the first datapoint"""
+        return self.first[key]
+
     @property
     def first(self) -> dict[str, str]:
         """First datapoint from the response"""


### PR DESCRIPTION
Adds `.__getitem__()` and `.get()` methods to `TSResponse` class.

This allows key-value lookup on the first datapoint.
Previosly you would assing `TSResponse.first` to a variable and do lookups on that.

Example from the `TSBot` class
https://github.com/jykob/TSBot/blob/c099c3d310d9aa6e93bd824f92040565ef89ca41/tsbot/bot.py#L542-L550

This can be cumbersome since many of the queries only return one point of data.

Above can be refactored to this:
https://github.com/jykob/TSBot/blob/d33e7acb5110f141d76470019a420331ba7d59db/tsbot/bot.py#L542-L550
