### PR TITLE
API Reference overhaul

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "latest"
+    python: "3.13"
   commands:
     - pip install .[docs]
     - python -m sphinx -c docs docs/source $READTHEDOCS_OUTPUT/html/

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.10"
+    python: "latest"
   commands:
     - pip install .[docs]
     - python -m sphinx -c docs docs/source $READTHEDOCS_OUTPUT/html/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_rtd_theme",
     "myst_parser",
     "autodoc_decorators",
+    "autodoc_type",
 ]
 
 source_suffix = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,10 +33,9 @@ author = "jykob"
 extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autodoc",
-    "sphinx_autodoc_typehints",
     "sphinx_rtd_theme",
     "myst_parser",
-    "autodoc-decoratormethod",
+    "autodoc_decorators",
 ]
 
 source_suffix = {
@@ -46,17 +45,12 @@ source_suffix = {
 }
 
 # -- AutoDoc Options --------------------
-autodoc_typehints = "signature"
+autodoc_typehints = "description"
 autodoc_typehints_format = "short"
 autodoc_member_order = "bysource"
 autodoc_preserve_defaults = True
 autoclass_content = "both"
 
-
-# -- AutoDoc Typehints Options --------------------
-always_use_bars_union = True
-typehints_defaults = "comma"
-typehints_use_rtype = False
 
 # -- MyST Options -----------------------
 myst_heading_anchors = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,6 @@ sys.path.append(os.path.abspath("./ext"))
 
 # -- Project information -----------------------------------------------------
 
-
 import datetime
 
 project = "TSBot"
@@ -48,10 +47,15 @@ source_suffix = {
 
 # -- AutoDoc Options --------------------
 autodoc_typehints = "signature"
+autodoc_typehints_format = "short"
 autodoc_member_order = "bysource"
 autodoc_preserve_defaults = True
 autoclass_content = "both"
 
+
+# -- AutoDoc Typehints Options --------------------
+always_use_bars_union = True
+typehints_defaults = "comma"
 
 # -- MyST Options -----------------------
 myst_heading_anchors = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ autoclass_content = "both"
 # -- AutoDoc Typehints Options --------------------
 always_use_bars_union = True
 typehints_defaults = "comma"
+typehints_use_rtype = False
 
 # -- MyST Options -----------------------
 myst_heading_anchors = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,8 @@ autoclass_content = "both"
 
 # -- MyST Options -----------------------
 myst_heading_anchors = 3
+myst_links_external_new_tab = True
+
 myst_enable_extensions = [
     "substitution",
 ]
@@ -83,4 +85,3 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["./static"]
 
 html_css_files = ["custom.css"]
-html_js_files = ["custom.js"]

--- a/docs/ext/autodoc-decoratormethod.py
+++ b/docs/ext/autodoc-decoratormethod.py
@@ -22,7 +22,7 @@ class DecoratorMethodDocumenter(MethodDocumenter):
     def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any) -> bool:
         return (
             super().can_document_member(member, membername, isattr, parent)
-            and bool(docstring := inspect.getdoc(member))
+            and (docstring := inspect.getdoc(member)) is not None
             and docstring.startswith(("decorator", "Decorator"))
         )
 

--- a/docs/ext/autodoc_decorators.py
+++ b/docs/ext/autodoc_decorators.py
@@ -21,7 +21,7 @@ class DecoratorFactoryMethodDocumenter(MethodDocumenter):
     objtype = "decoratorfactorymethod"
     directivetype = "decoratormethod"
 
-    priority = 10  # must be more than MethodDocumenter
+    priority = MethodDocumenter.priority + 10
 
     @classmethod
     def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any) -> bool:
@@ -32,6 +32,7 @@ class DecoratorFactoryMethodDocumenter(MethodDocumenter):
 
 
 def setup(app: Sphinx):
+    app.setup_extension("sphinx.ext.autodoc")
     app.add_autodocumenter(DecoratorFactoryMethodDocumenter)
 
     return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/docs/ext/autodoc_decorators.py
+++ b/docs/ext/autodoc_decorators.py
@@ -30,17 +30,6 @@ class DecoratorFactoryMethodDocumenter(MethodDocumenter):
             and member.__qualname__ in _DECORATOR_FACTORIES
         )
 
-    def format_signature(self, **kwargs: Any) -> str:
-        """
-        Remove the self argument from the signature.
-
-        `sphinx_autodoc_typehints` only removes the first argument (self) from the signature
-        if the `objtype == "method"`.
-        """
-
-        signature = super().format_signature(**kwargs)
-        return signature.replace("self, ", "")
-
 
 def setup(app: Sphinx):
     app.add_autodocumenter(DecoratorFactoryMethodDocumenter)

--- a/docs/ext/autodoc_type.py
+++ b/docs/ext/autodoc_type.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from typing import Any, TypeIs, cast
+from typing import Any, cast
 
 import sphinx
 from sphinx.application import Sphinx
@@ -11,12 +11,8 @@ from sphinx.util.typing import stringify_annotation
 TypeParams = typing.TypeVarTuple | typing.TypeVar | typing.ParamSpec
 
 
-def is_type_param(obj: Any) -> TypeIs[TypeParams]:
-    return isinstance(obj, TypeParams)
-
-
 def get_obj_type_args(obj: object) -> tuple[TypeParams, ...]:
-    if is_type_param(obj):
+    if isinstance(obj, TypeParams):
         return (obj,)
 
     results: list[TypeParams] = []

--- a/docs/ext/autodoc_type.py
+++ b/docs/ext/autodoc_type.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import typing
+from typing import Any, TypeIs, cast
+
+import sphinx
+from sphinx.application import Sphinx
+from sphinx.ext.autodoc import DataDocumenterMixinBase, ModuleLevelDocumenter
+from sphinx.util.typing import stringify_annotation
+
+TypeParams = typing.TypeVarTuple | typing.TypeVar | typing.ParamSpec
+
+
+def is_type_param(obj: Any) -> TypeIs[TypeParams]:
+    return isinstance(obj, TypeParams)
+
+
+def get_obj_type_args(obj: object) -> tuple[TypeParams, ...]:
+    if is_type_param(obj):
+        return (obj,)
+
+    results: list[TypeParams] = []
+
+    for arg in cast(list[Any], obj) if isinstance(obj, list) else typing.get_args(obj):
+        results.extend(result for result in get_obj_type_args(arg) if result not in results)
+
+    return tuple(results)
+
+
+def format_typevar(typevar: typing.TypeVar) -> str:
+    formatted = typevar.__name__
+
+    if bound := getattr(typevar, "__bound__", None):
+        formatted += f": {stringify_annotation(bound, "smart")}"
+
+    return formatted
+
+
+def format_paramspec(paramspec: typing.ParamSpec) -> str:
+    return f"**{paramspec.__name__}"
+
+
+def format_typevartuple(typevartuple: typing.TypeVarTuple) -> str:
+    return f"*{typevartuple.__name__}"
+
+
+def format_type_parameters(type_param: TypeParams) -> str:
+    match type_param:
+        case typing.TypeVar():
+            return format_typevar(type_param)
+        case typing.ParamSpec():
+            return format_paramspec(type_param)
+        case typing.TypeVarTuple():
+            return format_typevartuple(type_param)
+
+
+class TypeDocumenter(DataDocumenterMixinBase, ModuleLevelDocumenter):
+    objtype = "type"
+    directivetype = "type"
+
+    priority = ModuleLevelDocumenter.priority + 10
+
+    @classmethod
+    def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any) -> bool:
+        return False
+
+    def document_members(self, all_members: bool = False) -> None:
+        pass
+
+    def format_name(self) -> str:
+        ret = super().format_name()
+
+        if type_params := get_obj_type_args(self.object):
+            ret += f"[{', '.join(map(format_type_parameters, type_params))}]"
+
+        return ret
+
+    def add_directive_header(self, sig: str) -> None:
+        super().add_directive_header(sig)
+
+        sourcename = self.get_sourcename()
+
+        if self.config.autodoc_typehints_format == "short":
+            object_repr = stringify_annotation(self.object, "smart")
+        else:
+            object_repr = stringify_annotation(self.object, "fully-qualified-except-typing")
+
+        self.add_line("   :canonical: " + object_repr, sourcename)
+
+
+def setup(app: Sphinx):
+    app.setup_extension("sphinx.ext.autodoc")
+    app.add_autodocumenter(TypeDocumenter)
+
+    return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -42,6 +42,8 @@
     :exclude-members: from_server_response
 ```
 
+---
+
 ## Plugins
 
 ```{eval-rst}
@@ -60,12 +62,16 @@
 .. autodecorator:: tsbot.plugin.once
 ```
 
+---
+
 ## Tasks
 
 ```{eval-rst}
 .. autoclass:: tsbot.tasks.TSTask
     :members:
 ```
+
+---
 
 ## Exceptions
 

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -7,6 +7,8 @@
 
 ---
 
+## Context
+
 ```{eval-rst}
 .. class:: TSCtx(ctx)
 
@@ -18,13 +20,20 @@
 
 ---
 
+## Query Builder
+
 ```{eval-rst}
-.. automodule:: tsbot.query_builder
+.. autoclass:: tsbot.query_builder.query
+```
+
+```{eval-rst}
+.. autoclass:: tsbot.query_builder.TSQuery
     :members:
-    :exclude-members: Stringable
 ```
 
 ---
+
+## Responses
 
 ```{eval-rst}
 .. autoclass:: tsbot.response.TSResponse
@@ -36,7 +45,25 @@
 ## Plugins
 
 ```{eval-rst}
-.. automodule:: tsbot.plugin
+.. autoclass:: tsbot.plugin.TSPlugin
+```
+
+```{eval-rst}
+.. autodecorator:: tsbot.plugin.command
+```
+
+```{eval-rst}
+.. autodecorator:: tsbot.plugin.on
+```
+
+```{eval-rst}
+.. autodecorator:: tsbot.plugin.once
+```
+
+## Tasks
+
+```{eval-rst}
+.. autoclass:: tsbot.tasks.TSTask
     :members:
 ```
 

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -38,6 +38,7 @@
 ```{eval-rst}
 .. autoclass:: tsbot.response.TSResponse
     :members:
+    :special-members: __getitem__
     :exclude-members: from_server_response
 ```
 

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -38,7 +38,6 @@
 ```{eval-rst}
 .. autoclass:: tsbot.response.TSResponse
     :members:
-    :undoc-members:
     :exclude-members: from_server_response
 ```
 

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -7,6 +7,45 @@
 
 ---
 
+## Handlers
+
+```{eval-rst}
+.. autotype:: tsbot.events.EventHandler
+
+    A handler signature for event handlers.
+
+    .. code:: python
+
+        async def event_handler(bot: TSBot, ctx: TSCtx) -> None: ...
+
+.. autotype:: tsbot.commands.CommandHandler
+
+    A handler signature for command handlers.
+
+    .. code:: python
+
+        async def command_handler(bot: TSBot, ctx: TSCtx, arg1: str, arg2: str) -> None: ...
+
+.. autotype:: tsbot.commands.RawCommandHandler
+
+    A handler signature for raw command handlers.
+
+    .. code:: python
+
+        async def raw_command_handler(bot: TSBot, ctx: TSCtx, msg: str) -> None: ...
+
+.. autotype:: tsbot.tasks.TaskHandler
+
+    A handler signature for task handlers.
+
+    .. code:: python
+
+        async def task_handler(bot: TSBot) -> None: ...
+
+```
+
+---
+
 ## Context
 
 ```{eval-rst}
@@ -46,6 +85,30 @@
 
 ```{eval-rst}
 .. autoclass:: tsbot.plugin.TSPlugin
+
+.. autotype:: tsbot.plugin.PluginCommandHandler
+
+    A handler signature for plugin command handlers.
+
+    .. code:: python
+
+        async def plugin_command_handler(self, bot: TSBot, ctx: TSCtx, arg1: str) -> None: ...
+
+.. autotype:: tsbot.plugin.PluginRawCommandHandler
+
+    A handler signature for plugin raw command handlers.
+
+    .. code:: python
+
+        async def plugin_raw_command_handler(self, bot: TSBot, ctx: TSCtx, msg: str) -> None: ...
+
+.. autotype:: tsbot.plugin.PluginEventHandler
+
+    A handler signature for plugin event handlers.
+
+    .. code:: python
+
+        async def plugin_event_handler(self, bot: TSBot, ctx: TSCtx) -> None: ...
 
 .. autodecorator:: tsbot.plugin.command
 

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -10,7 +10,7 @@
 ## Context
 
 ```{eval-rst}
-.. class:: TSCtx(ctx)
+.. class:: tsbot.context.TSCtx(ctx)
 
    Thin wrapper around Pythons dictionary.
 

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -24,9 +24,7 @@
 
 ```{eval-rst}
 .. autoclass:: tsbot.query_builder.query
-```
 
-```{eval-rst}
 .. autoclass:: tsbot.query_builder.TSQuery
     :members:
 ```
@@ -48,17 +46,11 @@
 
 ```{eval-rst}
 .. autoclass:: tsbot.plugin.TSPlugin
-```
 
-```{eval-rst}
 .. autodecorator:: tsbot.plugin.command
-```
 
-```{eval-rst}
 .. autodecorator:: tsbot.plugin.on
-```
 
-```{eval-rst}
 .. autodecorator:: tsbot.plugin.once
 ```
 

--- a/docs/static/custom.js
+++ b/docs/static/custom.js
@@ -1,9 +1,0 @@
-"use strict";
-(() => {
-    document.addEventListener("DOMContentLoaded", () => {
-        const externalLinks = document.querySelectorAll("a.external");
-        for (const link of externalLinks) {
-            link.target = "_blank";
-        }
-    });
-})();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,7 @@ dev = [
     "python-dotenv >= 1.0.1",
 ]
 tests = ["pytest == 8.3.3", "pytest-asyncio == 0.24.0"]
-docs = [
-    "sphinx >= 7.3.7",
-    "myst-parser >= 2.0.0",
-    "sphinx-autodoc-typehints >= 2.1.0",
-    "sphinx_rtd_theme >= 2.0.0",
-]
+docs = ["sphinx >= 7.3.7", "myst-parser >= 2.0.0", "sphinx_rtd_theme >= 2.0.0"]
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ required-imports = ["from __future__ import annotations"]
 "examples/**/*" = ["ASYNC230", "ANN201"]
 "tests/**/*" = ["ANN2", "ASYNC110"]
 "docs/**/*" = ["ANN2"]
+"docs/conf.py" = ["I002"]
 "__init__.py" = ["I002"]
 
 

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -507,7 +507,7 @@ class TSBot:
         """
         Sends multiple raw commands to the server, ignoring the response.
 
-        :param queries: Iterable of raw query commands to be send to the server.
+        :param raw_queries: Iterable of raw query commands to be send to the server.
         """
 
         await self._connection.send_batched_raw(raw_queries)

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import inspect
 from collections.abc import Callable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast, overload
 
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -27,8 +27,6 @@ if TYPE_CHECKING:
     from tsbot.events import EventHandler, event_types
 
 _Ts = TypeVarTuple("_Ts")
-_TEH = TypeVar("_TEH", bound="EventHandler[Any]")
-_TCH = TypeVar("_TCH", bound="CommandHandler | RawCommandHandler")
 
 _DEFAULT_PORTS = {"ssh": 10022, "raw": 10011}
 
@@ -172,14 +170,14 @@ class TSBot:
     @overload
     def on(self, event_type: str) -> Callable[[EventHandler[Any]], EventHandler[Any]]: ...
 
-    def on(self, event_type: str) -> Callable[[_TEH], _TEH]:
+    def on(self, event_type: str) -> Callable[[EventHandler[Any]], EventHandler[Any]]:
         """
         Decorator to register event handlers.
 
         :param event_type: Name of the event.
         """
 
-        def event_decorator(func: _TEH) -> _TEH:
+        def event_decorator(func: EventHandler[Any]) -> EventHandler[Any]:
             self.register_event_handler(event_type, func)
             return func
 
@@ -238,14 +236,14 @@ class TSBot:
     @overload
     def once(self, event_type: str) -> Callable[[EventHandler[Any]], EventHandler[Any]]: ...
 
-    def once(self, event_type: str) -> Callable[[_TEH], _TEH]:
+    def once(self, event_type: str) -> Callable[[EventHandler[Any]], EventHandler[Any]]:
         """
         Decorator to register once handler.
 
         :param event_type: Name of the event.
         """
 
-        def once_decorator(func: _TEH) -> _TEH:
+        def once_decorator(func: EventHandler[Any]) -> EventHandler[Any]:
             self.register_once_handler(event_type, func)
             return func
 
@@ -322,7 +320,7 @@ class TSBot:
         raw: bool = False,
         hidden: bool = False,
         checks: Sequence[CommandHandler] = (),
-    ) -> Callable[[_TCH], _TCH]:
+    ) -> Callable[[CommandHandler], CommandHandler]:
         """
         Decorator to register command handlers.
 
@@ -333,7 +331,7 @@ class TSBot:
         :param checks: List of async functions to be called before the command is executed.
         """
 
-        def command_decorator(func: _TCH) -> _TCH:
+        def command_decorator(func: CommandHandler) -> CommandHandler:
             self.register_command(
                 command=command,
                 handler=func,

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -70,10 +70,18 @@ def command(
     raw: bool = False,
     hidden: bool = False,
     checks: Sequence[CommandHandler] = (),
-) -> Callable[[_TH], _TH]:
-    """Decorator to register plugin commands"""
+) -> Callable[[PluginCommandHandler], PluginCommandHandler]:
+    """
+    Decorator to register plugin commands
 
-    def command_decorator(func: _TH) -> _TH:
+    :param command: Name(s) of the command.
+    :param help_text: Text to be displayed when using **!help**.
+    :param raw: Skip message parsing and pass the rest of the message as the sole argument.
+    :param hidden: Hide this command from **!help**.
+    :param checks: List of async functions to be called before the command is executed.
+    """
+
+    def command_decorator(func: PluginCommandHandler) -> PluginCommandHandler:
         setattr(
             func,
             COMMAND_ATTR,
@@ -116,10 +124,14 @@ def on(
 
 def on(
     event_type: str,
-) -> Callable[[_TH], _TH]:
-    """Decorator to register plugin events"""
+) -> Callable[[PluginEventHandler[_TP, Any]], PluginEventHandler[_TP, Any]]:
+    """
+    Decorator to register plugin events
 
-    def event_decorator(func: _TH) -> _TH:
+    :param event_type: Name of the event.
+    """
+
+    def event_decorator(func: PluginEventHandler[_TP, Any]) -> PluginEventHandler[_TP, Any]:
         setattr(func, EVENT_ATTR, EventKwargs(event_type=event_type))
         return func
 
@@ -152,10 +164,14 @@ def once(
 
 def once(
     event_type: str,
-) -> Callable[[_TH], _TH]:
-    """Decorator to register plugin events to be ran only once"""
+) -> Callable[[PluginEventHandler[_TP, Any]], PluginEventHandler[_TP, Any]]:
+    """
+    Decorator to register plugin events to be ran only once
 
-    def once_decorator(func: _TH) -> _TH:
+    :param event_type: Name of the event.
+    """
+
+    def once_decorator(func: PluginEventHandler[_TP, Any]) -> PluginEventHandler[_TP, Any]:
         setattr(func, ONCE_ATTR, EventKwargs(event_type=event_type))
         return func
 

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
 
 _TP = TypeVar("_TP", bound="TSPlugin", contravariant=True)
 _TC = TypeVar("_TC", contravariant=True)
-_TH = TypeVar("_TH")
 
 PluginEventHandler = Callable[[_TP, "bot.TSBot", _TC], Coroutine[None, None, None]]
 PluginRawCommandHandler = Callable[

--- a/tsbot/response.py
+++ b/tsbot/response.py
@@ -15,25 +15,25 @@ class TSResponse:
     Class to represent the response to a query from a Teamspeak server.
     """
 
-    data: tuple[dict[str, str], ...]
-    error_id: int
-    msg: str
+    data: tuple[dict[str, str], ...]  #: The response data.
+    error_id: int  #: Id of the error if any.
+    msg: str  #: Message of the error if any.
 
     def __iter__(self) -> Generator[dict[str, str], None, None]:
         yield from self.data
 
     def __getitem__(self, key: str) -> str:
-        """Get the value of a key from the first datapoint"""
+        """Get the value of a key from the first response dict"""
         return self.first[key]
 
     @property
     def first(self) -> dict[str, str]:
-        """First datapoint from the response"""
+        """The first dict from the response data"""
         return self.data[0]
 
     @property
     def last(self) -> dict[str, str]:
-        """Last datapoint from the response"""
+        """The last dict from the response data"""
         return self.data[-1]
 
     @overload
@@ -43,7 +43,7 @@ class TSResponse:
     def get(self, key: str, default: str, /) -> str: ...
 
     def get(self, key: str, default: str | None = None) -> str | None:
-        """Get the value of a key from the first datapoint"""
+        """Get the value of a key from the first response dict"""
         return self.first.get(key, default)
 
     @classmethod

--- a/tsbot/tasks/task.py
+++ b/tsbot/tasks/task.py
@@ -25,6 +25,7 @@ class TSTask:
     task: asyncio.Task[None] | None = None
 
     def cancel(self) -> None:
+        """Cancel the the underlying task"""
         if self.task:
             self.task.cancel()
 


### PR DESCRIPTION
Fix some issues with the API Reference.

* Remove `sphinx-autodoc-typehints`.
    * Doesn't handle `decoratormethod` directives correctly.
* Add `TypeDocumenter`
    * Documents type definitions automatically