### PR TITLE
Every task immediate

### DIFF
--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -511,6 +511,7 @@ class TSBot:
         handler: tasks.TaskHandler[Unpack[_Ts]],
         *args: Unpack[_Ts],
         name: str | None = None,
+        immediate: bool = False,
     ) -> tasks.TSTask:
         """
         Register a background task.
@@ -530,10 +531,11 @@ class TSBot:
         :param handler: Async function to be called when the task is executed.
         :param args: Optional arguments to be passed to the handler.
         :param name: Name of the task.
+        :param immediate: If the task handler should be executed immediately.
         :return: Instance of :class:`~tsbot.tasks.TSTask` created.
         """
         task = tasks.TSTask(
-            handler=tasks.every(handler, seconds),  # type: ignore
+            handler=tasks.every(handler, seconds, immediate),  # type: ignore
             args=args,
             name=name,
         )

--- a/tsbot/tasks/task.py
+++ b/tsbot/tasks/task.py
@@ -30,9 +30,16 @@ class TSTask:
             self.task.cancel()
 
 
-def every(every_handler: TaskHandler[Unpack[_Ts]], seconds: float) -> TaskHandler[Unpack[_Ts]]:
+def every(
+    every_handler: TaskHandler[Unpack[_Ts]],
+    seconds: float,
+    immediate: bool = False,
+) -> TaskHandler[Unpack[_Ts]]:
     @functools.wraps(every_handler)
     async def every_wrapper(bot: bot.TSBot, *args: Unpack[_Ts]) -> None:
+        if immediate:
+            await every_handler(bot, *args)
+
         while True:
             await asyncio.sleep(seconds)
             await every_handler(bot, *args)


### PR DESCRIPTION
Add option to run every task handlers to be executed immediately after registering them.

Example:
```python
DATA_COLLECTION_INTERVAL = 60


@bot.on("connect")
async def on_connect(bot: TSBot, ctx: None):
    async def collect_data_task(bot: TSBot) -> None:
        data = await bot.send_raw("clientlist")
        # aggregate data somewhere

    task = bot.register_every_task(
        DATA_COLLECTION_INTERVAL,
        collect_data_task,
        immediate=True,
    )

    async def cancel_collect_task(bot: TSBot, ctx: None) -> None:
        task.cancel()

    bot.register_once_handler("disconnect", cancel_task)
```

The `collect_data_task` handler is executed once the task has been registered.