### PR TITLE
Default plugins parameter

### DIFF
--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -98,3 +98,12 @@ bot = TSBot(
 ```
 
 This will load the `CustomPlugin` plugin instance along with the default plugins.
+
+You can also disable all the default plugins by passing an empty tuple to the `default_plugins` parameter.
+
+```python
+bot = TSBot(
+    ...
+    default_plugins=(),
+)
+```

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -60,3 +60,41 @@ or by passing `-format detailed` as a keyword argument.
 If no command were found or the command is `hidden`, the `help` command raises
 [TSCommandError](tsbot.exceptions.TSCommandError) telling that no command was found.
 ```
+
+---
+
+### Customizing default plugins
+
+You can customize the default plugins by overriding them in your bot.
+
+For example, if you want to remove the `Help` plugin from the default plugins, you can do it like this:
+
+```python
+from tsbot import DEFAULT_PLUGINS, TSBot
+
+bot = TSBot(
+    ...
+    default_plugins=DEFAULT_PLUGINS.remove(DEFAULT_PLUGINS.help),
+)
+```
+
+This will remove the `Help` plugin from the default plugins.
+
+You can also add your own plugins to default plugins. For example, if you want to add a custom plugin
+to the default plugins, you can do it like this:
+
+```python
+from tsbot import DEFAULT_PLUGINS, TSBot, plugin
+
+class CustomPlugin(plugin.TSPlugin):
+    @plugin.command("custom")
+    async def custom_command(self, bot: TSBot, ctx: TSCtx):
+        await bot.respond(ctx, "Custom command")
+
+bot = TSBot(
+    ...
+    default_plugins=(*DEFAULT_PLUGINS, CustomPlugin()),
+)
+```
+
+This will load the `CustomPlugin` plugin instance along with the default plugins.

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -102,6 +102,8 @@ This will load the `CustomPlugin` plugin instance along with the default plugins
 You can also disable all the default plugins by passing an empty tuple to the `default_plugins` parameter.
 
 ```python
+from tsbot import TSBot
+
 bot = TSBot(
     ...
     default_plugins=(),

--- a/tsbot/__init__.py
+++ b/tsbot/__init__.py
@@ -1,6 +1,7 @@
 from tsbot.bot import TSBot
 from tsbot.context import TSCtx
+from tsbot.default_plugins import DEFAULT_PLUGINS
 from tsbot.query_builder import query
 from tsbot.tasks.task import TSTask
 
-__all__ = ("TSBot", "TSCtx", "TSTask", "query")
+__all__ = ("DEFAULT_PLUGINS", "TSBot", "TSCtx", "TSTask", "query")

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -58,6 +58,7 @@ class TSBot:
         ratelimit_calls: int = 10,
         ratelimit_period: float = 3,
         query_timeout: float = 5,
+        default_plugins: Iterable[plugin.TSPlugin] = default_plugins.DEFAULT_PLUGINS,
     ) -> None:
         """
         :param username: Login name of the query account.
@@ -74,6 +75,7 @@ class TSBot:
         :param ratelimit_calls: Calls per period.
         :param ratelimit_period: Period interval.
         :param query_timeout: Timeout for each query command in seconds.
+        :param default_plugins: Plugins that will be loaded by default.
         """  # noqa: D205
         if nickname is not None and not nickname:
             raise TypeError("Bot nickname cannot be empty")
@@ -112,7 +114,7 @@ class TSBot:
         self.register_event_handler("connect", self._on_connect)
         self.register_event_handler("textmessage", self._command_manager.handle_command_event)
 
-        self.load_plugin(default_plugins.Help(), default_plugins.KeepAlive())
+        self.load_plugin(*default_plugins)
 
     @property
     def uid(self) -> str:

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -108,7 +108,11 @@ class TSBot:
 
         self._bot_info = BotInfo()
         self._closing = asyncio.Event()
-        self._init()
+
+        self.register_event_handler("connect", self._on_connect)
+        self.register_event_handler("textmessage", self._command_manager.handle_command_event)
+
+        self.load_plugin(default_plugins.Help(), default_plugins.KeepAlive())
 
     @property
     def uid(self) -> str:
@@ -129,12 +133,6 @@ class TSBot:
     def connected(self) -> bool:
         """Is the bot currently connected to a server."""
         return self._connection.connected
-
-    def _init(self) -> None:
-        self.register_event_handler("connect", self._on_connect)
-        self.register_event_handler("textmessage", self._command_manager.handle_command_event)
-
-        self.load_plugin(default_plugins.Help(), default_plugins.KeepAlive())
 
     def emit(self, event_name: str, ctx: Any | None = None) -> None:
         """

--- a/tsbot/default_plugins/__init__.py
+++ b/tsbot/default_plugins/__init__.py
@@ -1,4 +1,5 @@
+from tsbot.default_plugins.default_plugins import DEFAULT_PLUGINS
 from tsbot.default_plugins.help import Help
 from tsbot.default_plugins.keepalive import KeepAlive
 
-__all__ = ("Help", "KeepAlive")
+__all__ = ("DEFAULT_PLUGINS", "Help", "KeepAlive")

--- a/tsbot/default_plugins/default_plugins.py
+++ b/tsbot/default_plugins/default_plugins.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+from tsbot.default_plugins.help import Help
+from tsbot.default_plugins.keepalive import KeepAlive
+
+if TYPE_CHECKING:
+    from tsbot.plugin import TSPlugin
+
+
+class _DefaultPlugins(NamedTuple):
+    help: Help
+    keepalive: KeepAlive
+
+    def remove(self, *plugins: TSPlugin) -> tuple[TSPlugin, ...]:
+        return tuple(filter(lambda p: p not in plugins, self))
+
+
+DEFAULT_PLUGINS = _DefaultPlugins(help=Help(), keepalive=KeepAlive())


### PR DESCRIPTION
PR that adds ability to change the plugins that will be loaded by default.

This adds ability to add your own plugin instances without calling `.load_plugin()` method later on, or remove default plugins such as `Help` plugin.

```python
from tsbot import DEFAULT_PLUGINS, TSBot

bot = TSBot(
    ...
    default_plugins=DEFAULT_PLUGINS.remove(DEFAULT_PLUGINS.help),
)
```